### PR TITLE
changes due to AMReX changes

### DIFF
--- a/Source/MaestroFillData.cpp
+++ b/Source/MaestroFillData.cpp
@@ -42,9 +42,9 @@ Maestro::FillPatch (int lev, Real time, MultiFab& mf,
         Vector<Real> stime;
         GetData(0, time, smf, stime, mf_old, mf_new);
 
-        PhysBCFunctMaestro physbc(geom[lev],bcs,BndryFunctBase(phifill));
+        PhysBCFunctMaestro physbc(geom[lev],bcs,BndryFuncArray(phifill));
         FillPatchSingleLevel(mf, time, smf, stime, srccomp, destcomp, ncomp,
-                             geom[lev], physbc);
+                             geom[lev], physbc, 0);
     }
     else
     {
@@ -53,15 +53,15 @@ Maestro::FillPatch (int lev, Real time, MultiFab& mf,
         GetData(lev-1, time, cmf, ctime, mf_old, mf_new);
         GetData(lev, time, fmf, ftime, mf_old, mf_new);
 
-        PhysBCFunctMaestro cphysbc(geom[lev-1],bcs,BndryFunctBase(phifill));
-        PhysBCFunctMaestro fphysbc(geom[lev  ],bcs,BndryFunctBase(phifill));
+        PhysBCFunctMaestro cphysbc(geom[lev-1],bcs,BndryFuncArray(phifill));
+        PhysBCFunctMaestro fphysbc(geom[lev  ],bcs,BndryFuncArray(phifill));
 
         Interpolater* mapper = &cell_cons_interp;
 
         FillPatchTwoLevels(mf, time, cmf, ctime, fmf, ftime,
                            srccomp, destcomp, ncomp, geom[lev-1], geom[lev],
-                           cphysbc, fphysbc, refRatio(lev-1),
-                           mapper, bcs);
+                           cphysbc, 0, fphysbc, 0, refRatio(lev-1),
+                           mapper, bcs, 0);
     }
 }
 
@@ -89,13 +89,13 @@ Maestro::FillCoarsePatch (int lev, Real time, MultiFab& mf,
         Abort("FillCoarsePatch: how did this happen?");
     }
 
-    PhysBCFunctMaestro cphysbc(geom[lev-1],bcs,BndryFunctBase(phifill));
-    PhysBCFunctMaestro fphysbc(geom[lev  ],bcs,BndryFunctBase(phifill));
+    PhysBCFunctMaestro cphysbc(geom[lev-1],bcs,BndryFuncArray(phifill));
+    PhysBCFunctMaestro fphysbc(geom[lev  ],bcs,BndryFuncArray(phifill));
 
     Interpolater* mapper = &cell_cons_interp;
     InterpFromCoarseLevel(mf, time, *cmf[0], srccomp, destcomp, ncomp, geom[lev-1], geom[lev],
-                          cphysbc, fphysbc, refRatio(lev-1),
-                          mapper, bcs);
+                          cphysbc, 0, fphysbc, 0, refRatio(lev-1),
+                          mapper, bcs, 0);
 }
 
 // utility to copy in data from mf_old and/or mf_new into mf

--- a/Source/PhysBCFunctMaestro.H
+++ b/Source/PhysBCFunctMaestro.H
@@ -3,6 +3,9 @@
 
 #include <AMReX_PhysBCFunct.H>
 
+using PhysBCFunctMaestro = amrex::PhysBCFunct<amrex::BndryFuncArray>;
+
+#if 0
 class PhysBCFunctMaestro
     : public amrex::PhysBCFunctBase
 {
@@ -30,5 +33,6 @@ private:
     amrex::Vector<amrex::BCRec>            m_bcr;
     std::unique_ptr<amrex::BndryFunctBase> m_bc_func;
 };
+#endif
 
 #endif

--- a/Source/PhysBCFunctMaestro.cpp
+++ b/Source/PhysBCFunctMaestro.cpp
@@ -3,6 +3,8 @@
 
 using namespace amrex;
 
+#if 0
+
 PhysBCFunctMaestro::PhysBCFunctMaestro (const Geometry& geom,
                                         const Vector<BCRec>& bcr,
                                         const BndryFunctBase& func)
@@ -77,3 +79,5 @@ PhysBCFunctMaestro::FillBoundary (MultiFab& mf, int dcomp, int ncomp, Real time)
         }
     }
 }
+
+#endif


### PR DESCRIPTION
In AMReX development branch, there are some changes to fillpatch functions.  This requires MAESTROeX to be updated.

Note that now `PhysBCFunctMaestro` is simply an alias to `amrex::PhysBCFunct<amrex::BndryFuncArray>`.  If that's insufficient, MAESTROeX could have its own class.  The only difference between the old and new `PhysBCFuncMasetro` is that the new one does not have `if (mf.nGrow() == 0) return;` in `FillBoundary`.  I think the old one is incorrect because in fillpatch we do use the function to fill "valid" region data outside the domain when we need to do coarse/fine interpolation near the physical boundary.
