### PR TITLE
give initialization plots plot_base_name_prefix

### DIFF
--- a/Source/MaestroInit.cpp
+++ b/Source/MaestroInit.cpp
@@ -25,9 +25,9 @@ Maestro::Init ()
 
         if (plot_int > 0) {
 
-	    // Need to fill normal vector to compute velrc in plotfile 
+	    // Need to fill normal vector to compute velrc in plotfile
 	    if (spherical) { MakeNormal(); }
-	    
+
             Print() << "\nWriting plotfile plt_InitData after InitData" << std::endl;
             WritePlotFile(9999999,t_old,0,rho0_old,rhoh0_old,p0_old,gamma1bar_old,uold,sold,S_cc_old);
         }
@@ -57,7 +57,7 @@ Maestro::Init ()
                 cell_cc_to_r[lev].define(grids[lev], dmap[lev], 1, 0);
             }
             pi[lev].define(convert(grids[lev],nodal_flag), dmap[lev], 1, 0);             // nodal
-	    
+
         }
     }
 
@@ -66,18 +66,18 @@ Maestro::Init ()
     init_multilevel(tag_array.dataPtr(),&finest_level);
 
     compute_cutoff_coords(rho0_old.dataPtr());
-    
+
     if (spherical == 1) {
         MakeNormal();
         MakeCCtoRadii();
     }
 
     if (do_sponge) {
-	if (use_exact_base_state) {
-	    init_sponge_irreg(rho0_old.dataPtr(),r_cc_loc.dataPtr(),r_edge_loc.dataPtr());
-	} else {
-	    init_sponge(rho0_old.dataPtr());
-	}
+    	if (use_exact_base_state) {
+    	    init_sponge_irreg(rho0_old.dataPtr(),r_cc_loc.dataPtr(),r_edge_loc.dataPtr());
+    	} else {
+    	    init_sponge(rho0_old.dataPtr());
+    	}
     }
 
     // make gravity
@@ -112,7 +112,7 @@ Maestro::Init ()
         for (int i=0; i<beta0_old.size(); ++i) {
             beta0_nm1[i] = beta0_old[i];
 	}
-	
+
         // initial projection
         if (do_initial_projection) {
             Print() << "Doing initial projection" << std::endl;
@@ -264,7 +264,7 @@ Maestro::InitData ()
             // set rhoh0 to be the average
             Average(sold,rhoh0_old,RhoH);
         }
-	
+
 	// set tempbar to be the average
 	Average(sold,tempbar,Temp);
 	for (int i=0; i<tempbar.size(); ++i) {

--- a/Source/MaestroPlot.cpp
+++ b/Source/MaestroPlot.cpp
@@ -27,7 +27,7 @@ Maestro::WritePlotFile (const int step,
 	std::string plotfilename;
 
 	if (step == 9999999) {
-		if (plot_base_name.last() == '_') {
+		if (plot_base_name.back() == '_') {
 			plotfilename = plot_base_name + "InitData";
 		} else {
 			plotfilename = plot_base_name + "InitData";
@@ -35,14 +35,14 @@ Maestro::WritePlotFile (const int step,
 
 	}
 	else if (step == 9999998) {
-		if (plot_base_name.last() == '_') {
+		if (plot_base_name.back() == '_') {
 			plotfilename = plot_base_name + "after_InitProj";
 		} else {
 			plotfilename = plot_base_name + "_after_InitProj";
 		}
 	}
 	else if (step == 9999997) {
-		if (plot_base_name.last() == '_') {
+		if (plot_base_name.back() == '_') {
 			plotfilename = plot_base_name + "after_DivuIter";
 		} else {
 			plotfilename = plot_base_name + "_after_DivuIter";

--- a/Source/MaestroPlot.cpp
+++ b/Source/MaestroPlot.cpp
@@ -27,13 +27,26 @@ Maestro::WritePlotFile (const int step,
 	std::string plotfilename;
 
 	if (step == 9999999) {
-		plotfilename = "plt_InitData";
+		if (plot_base_name.last() == '_') {
+			plotfilename = plot_base_name + "InitData";
+		} else {
+			plotfilename = plot_base_name + "InitData";
+		}
+
 	}
 	else if (step == 9999998) {
-		plotfilename = "plt_after_InitProj";
+		if (plot_base_name.last() == '_') {
+			plotfilename = plot_base_name + "after_InitProj";
+		} else {
+			plotfilename = plot_base_name + "_after_InitProj";
+		}
 	}
 	else if (step == 9999997) {
-		plotfilename = "plt_after_DivuIter";
+		if (plot_base_name.last() == '_') {
+			plotfilename = plot_base_name + "after_DivuIter";
+		} else {
+			plotfilename = plot_base_name + "_after_DivuIter";
+		}
 	}
 	else {
 		plotfilename = PlotFileName(step);
@@ -974,17 +987,17 @@ Maestro::MakeMagvel (const Vector<MultiFab>& vel,
 	// timer for profiling
 	BL_PROFILE_VAR("Maestro::MakeMagvel()",MakeMagvel);
 
-        Vector<std::array< MultiFab, AMREX_SPACEDIM > > w0mac(finest_level+1);
-	
+	Vector<std::array< MultiFab, AMREX_SPACEDIM > > w0mac(finest_level+1);
+
 #if (AMREX_SPACEDIM == 3)
-        if (spherical == 1) {
-            for (int lev=0; lev<=finest_level; ++lev) {
-                w0mac[lev][0].define(convert(grids[lev],nodal_flag_x), dmap[lev], 1, 1);
-                w0mac[lev][1].define(convert(grids[lev],nodal_flag_y), dmap[lev], 1, 1);
-                w0mac[lev][2].define(convert(grids[lev],nodal_flag_z), dmap[lev], 1, 1);
-            }
-            MakeW0mac(w0mac);
-        }
+	if (spherical == 1) {
+		for (int lev=0; lev<=finest_level; ++lev) {
+			w0mac[lev][0].define(convert(grids[lev],nodal_flag_x), dmap[lev], 1, 1);
+			w0mac[lev][1].define(convert(grids[lev],nodal_flag_y), dmap[lev], 1, 1);
+			w0mac[lev][2].define(convert(grids[lev],nodal_flag_z), dmap[lev], 1, 1);
+		}
+		MakeW0mac(w0mac);
+	}
 #endif
 
 	for (int lev=0; lev<=finest_level; ++lev) {
@@ -1022,10 +1035,10 @@ Maestro::MakeMagvel (const Vector<MultiFab>& vel,
 
 				// Get the index space of the valid region
 				const Box& tileBox = mfi.tilebox();
-                                
-                                MultiFab& w0macx_mf = w0mac[lev][0];
-                                MultiFab& w0macy_mf = w0mac[lev][1];
-                                MultiFab& w0macz_mf = w0mac[lev][2];
+
+				MultiFab& w0macx_mf = w0mac[lev][0];
+				MultiFab& w0macy_mf = w0mac[lev][1];
+				MultiFab& w0macz_mf = w0mac[lev][2];
 
 				// call fortran subroutine
 				// use macros in AMReX_ArrayLim.H to pass in each FAB's data,
@@ -1033,9 +1046,9 @@ Maestro::MakeMagvel (const Vector<MultiFab>& vel,
 				// We will also pass "validBox", which specifies the "valid" region.
 				make_magvel_sphr(ARLIM_3D(tileBox.loVect()), ARLIM_3D(tileBox.hiVect()),
 				                 BL_TO_FORTRAN_3D(vel_mf[mfi]),
-                                                 BL_TO_FORTRAN_3D(w0macx_mf[mfi]),
-                                                 BL_TO_FORTRAN_3D(w0macy_mf[mfi]),
-                                                 BL_TO_FORTRAN_3D(w0macz_mf[mfi]),
+				                 BL_TO_FORTRAN_3D(w0macx_mf[mfi]),
+				                 BL_TO_FORTRAN_3D(w0macy_mf[mfi]),
+				                 BL_TO_FORTRAN_3D(w0macz_mf[mfi]),
 				                 BL_TO_FORTRAN_3D(magvel_mf[mfi]));
 			}
 		}


### PR DESCRIPTION
This ensures that the plots `plt_InitData`, `plt_after_InitProj` and `plt_after_Divu` end up in the same directory as the rest of the plotfiles (issue #41 )