### PR TITLE
use enum type with -ve values to flag setup plots

### DIFF
--- a/Source/Maestro.H
+++ b/Source/Maestro.H
@@ -85,7 +85,7 @@ private:
 			const amrex::Vector<std::array< amrex::MultiFab,AMREX_SPACEDIM > >& w0mac,
                         const amrex::Vector<amrex::Real>& w0_force,
 			const amrex::Vector<amrex::MultiFab>& w0_force_cart,
-			const amrex::Vector<amrex::Real>& beta0, 
+			const amrex::Vector<amrex::Real>& beta0,
 			const int is_predictor);
 
     void MakeUtrans (const amrex::Vector<amrex::MultiFab>& utilde,
@@ -182,7 +182,7 @@ private:
                         int comp, int bccomp,
                         const amrex::Vector<amrex::BCRec>& bcs_in,
                         bool flag);
-    
+
     void PutInPertForm (int level, amrex::Vector<amrex::MultiFab>& scal,
                         const amrex::Vector<amrex::Real>& s0,
                         int comp, int bccomp,
@@ -340,7 +340,7 @@ private:
                            int is_output_a_vector,
                            const amrex::Vector<amrex::BCRec>& bcs = amrex::Vector<amrex::BCRec>(),
                            int sbccomp = 0);
-    
+
     void Put1dArrayOnCart (int level, const amrex::Vector<amrex::Real>& s0,
                            amrex::Vector<amrex::MultiFab>& s0_cart,
                            int is_input_edge_centered,
@@ -938,6 +938,9 @@ private:
     // therefore flux_reg[0] and flux_reg[max_level] are never actually
     // used in the reflux operation
     amrex::Vector<std::unique_ptr<amrex::FluxRegister> > flux_reg_s;
+
+    // flag for writing plotfiles
+    enum plotfile_flag {plotInitData = -9999999, plotInitProj = -9999998, plotDivuIter = -9999997};
 
 };
 

--- a/Source/MaestroInit.cpp
+++ b/Source/MaestroInit.cpp
@@ -25,11 +25,11 @@ Maestro::Init ()
 
         if (plot_int > 0) {
 
-	    // Need to fill normal vector to compute velrc in plotfile 
+	    // Need to fill normal vector to compute velrc in plotfile
 	    if (spherical) { MakeNormal(); }
-	    
+
             Print() << "\nWriting plotfile plt_InitData after InitData" << std::endl;
-            WritePlotFile(9999999,t_old,0,rho0_old,rhoh0_old,p0_old,gamma1bar_old,uold,sold,S_cc_old);
+            WritePlotFile(plotInitData,t_old,0,rho0_old,rhoh0_old,p0_old,gamma1bar_old,uold,sold,S_cc_old);
         }
     }
     else {
@@ -57,7 +57,7 @@ Maestro::Init ()
                 cell_cc_to_r[lev].define(grids[lev], dmap[lev], 1, 0);
             }
             pi[lev].define(convert(grids[lev],nodal_flag), dmap[lev], 1, 0);             // nodal
-	    
+
         }
     }
 
@@ -66,7 +66,7 @@ Maestro::Init ()
     init_multilevel(tag_array.dataPtr(),&finest_level);
 
     compute_cutoff_coords(rho0_old.dataPtr());
-    
+
     if (spherical == 1) {
         MakeNormal();
         MakeCCtoRadii();
@@ -112,7 +112,7 @@ Maestro::Init ()
         for (int i=0; i<beta0_old.size(); ++i) {
             beta0_nm1[i] = beta0_old[i];
 	}
-	
+
         // initial projection
         if (do_initial_projection) {
             Print() << "Doing initial projection" << std::endl;
@@ -120,7 +120,7 @@ Maestro::Init ()
 
             if (plot_int > 0) {
                 Print() << "\nWriting plotfile plt_after_InitProj after InitProj" << std::endl;
-                WritePlotFile(9999998,t_old,0,rho0_old,rhoh0_old,p0_old,gamma1bar_old,uold,sold,S_cc_old);
+                WritePlotFile(plotInitProj,t_old,0,rho0_old,rhoh0_old,p0_old,gamma1bar_old,uold,sold,S_cc_old);
             }
         }
 
@@ -136,7 +136,7 @@ Maestro::Init ()
 
             if (plot_int > 0) {
                 Print() << "\nWriting plotfile plt_after_DivuIter after final DivuIter" << std::endl;
-                WritePlotFile(9999997,t_old,dt,rho0_old,rhoh0_old,p0_old,gamma1bar_old,uold,sold,S_cc_old);
+                WritePlotFile(plotDivuIter,t_old,dt,rho0_old,rhoh0_old,p0_old,gamma1bar_old,uold,sold,S_cc_old);
             }
         }
 
@@ -264,7 +264,7 @@ Maestro::InitData ()
             // set rhoh0 to be the average
             Average(sold,rhoh0_old,RhoH);
         }
-	
+
 	// set tempbar to be the average
 	Average(sold,tempbar,Temp);
 	for (int i=0; i<tempbar.size(); ++i) {

--- a/Source/MaestroPlot.cpp
+++ b/Source/MaestroPlot.cpp
@@ -26,13 +26,13 @@ Maestro::WritePlotFile (const int step,
 
 	std::string plotfilename;
 
-	if (step == 9999999) {
+	if (step == plotInitData) {
 		plotfilename = "plt_InitData";
 	}
-	else if (step == 9999998) {
+	else if (step == plotInitProj) {
 		plotfilename = "plt_after_InitProj";
 	}
-	else if (step == 9999997) {
+	else if (step == plotDivuIter) {
 		plotfilename = "plt_after_DivuIter";
 	}
 	else {
@@ -975,7 +975,7 @@ Maestro::MakeMagvel (const Vector<MultiFab>& vel,
 	BL_PROFILE_VAR("Maestro::MakeMagvel()",MakeMagvel);
 
         Vector<std::array< MultiFab, AMREX_SPACEDIM > > w0mac(finest_level+1);
-	
+
 #if (AMREX_SPACEDIM == 3)
         if (spherical == 1) {
             for (int lev=0; lev<=finest_level; ++lev) {
@@ -1022,7 +1022,7 @@ Maestro::MakeMagvel (const Vector<MultiFab>& vel,
 
 				// Get the index space of the valid region
 				const Box& tileBox = mfi.tilebox();
-                                
+
                                 MultiFab& w0macx_mf = w0mac[lev][0];
                                 MultiFab& w0macy_mf = w0mac[lev][1];
                                 MultiFab& w0macz_mf = w0mac[lev][2];


### PR DESCRIPTION
This uses an enum type with -ve values to tell `WritePlotFile` to generate plots during setup.