### PR TITLE
plot abar

### DIFF
--- a/Source/Maestro.H
+++ b/Source/Maestro.H
@@ -85,7 +85,7 @@ private:
 			const amrex::Vector<std::array< amrex::MultiFab,AMREX_SPACEDIM > >& w0mac,
                         const amrex::Vector<amrex::Real>& w0_force,
 			const amrex::Vector<amrex::MultiFab>& w0_force_cart,
-			const amrex::Vector<amrex::Real>& beta0, 
+			const amrex::Vector<amrex::Real>& beta0,
 			const int is_predictor);
 
     void MakeUtrans (const amrex::Vector<amrex::MultiFab>& utilde,
@@ -182,7 +182,7 @@ private:
                         int comp, int bccomp,
                         const amrex::Vector<amrex::BCRec>& bcs_in,
                         bool flag);
-    
+
     void PutInPertForm (int level, amrex::Vector<amrex::MultiFab>& scal,
                         const amrex::Vector<amrex::Real>& s0,
                         int comp, int bccomp,
@@ -340,7 +340,7 @@ private:
                            int is_output_a_vector,
                            const amrex::Vector<amrex::BCRec>& bcs = amrex::Vector<amrex::BCRec>(),
                            int sbccomp = 0);
-    
+
     void Put1dArrayOnCart (int level, const amrex::Vector<amrex::Real>& s0,
                            amrex::Vector<amrex::MultiFab>& s0_cart,
                            int is_input_edge_centered,
@@ -622,6 +622,10 @@ private:
     void MakePiDivu (const amrex::Vector<amrex::MultiFab>& vel,
                    const amrex::Vector<amrex::MultiFab>& pi_cc,
                    amrex::Vector<amrex::MultiFab>& pidivu);
+
+    // mass fractions of the species
+    void MakeAbar(const amrex::Vector<amrex::MultiFab>& state,
+                amrex::Vector<amrex::MultiFab>& abar);
 
     // end MaestroPlot.cpp functions
     ////////////

--- a/Source/MaestroPlot.cpp
+++ b/Source/MaestroPlot.cpp
@@ -197,6 +197,14 @@ Maestro::PlotFileMF (const int nPlot,
 			}
 		}
 		dest_comp += NumSpec;
+
+        // abar
+		MakeAbar(s_in, tempmf);
+		for (int i = 0; i <= finest_level; ++i) {
+			plot_mf_data[i]->copy((tempmf[i]),0,dest_comp,1);
+		}
+		++dest_comp;
+
 	}
 
 	Vector<MultiFab> stemp             (finest_level+1);
@@ -578,7 +586,7 @@ Maestro::PlotFileVarNames (int * nPlot) const
 	// thermal, conductivity
 	(*nPlot) = 2*AMREX_SPACEDIM + Nscal + 21;
 
-	if (plot_spec) (*nPlot) += NumSpec; // X
+	if (plot_spec) (*nPlot) += NumSpec + 1; // X + 1 (abar)
 	if (plot_spec || plot_omegadot) (*nPlot) += NumSpec; // omegadot
 
 	if (plot_Hext) (*nPlot)++;
@@ -650,6 +658,8 @@ Maestro::PlotFileVarNames (int * nPlot) const
 
 			delete [] spec_name;
 		}
+
+        names[cnt++] = "abar";
 	}
 
 	if (plot_spec || plot_omegadot) {
@@ -975,7 +985,7 @@ Maestro::MakeMagvel (const Vector<MultiFab>& vel,
 	BL_PROFILE_VAR("Maestro::MakeMagvel()",MakeMagvel);
 
         Vector<std::array< MultiFab, AMREX_SPACEDIM > > w0mac(finest_level+1);
-	
+
 #if (AMREX_SPACEDIM == 3)
         if (spherical == 1) {
             for (int lev=0; lev<=finest_level; ++lev) {
@@ -1022,7 +1032,7 @@ Maestro::MakeMagvel (const Vector<MultiFab>& vel,
 
 				// Get the index space of the valid region
 				const Box& tileBox = mfi.tilebox();
-                                
+
                                 MultiFab& w0macx_mf = w0mac[lev][0];
                                 MultiFab& w0macy_mf = w0mac[lev][1];
                                 MultiFab& w0macz_mf = w0mac[lev][2];
@@ -1384,4 +1394,43 @@ Maestro::MakePiDivu (const Vector<MultiFab>& vel,
 	// average down and fill ghost cells
 	AverageDown(pidivu,0,1);
 	FillPatch(t_old,pidivu,pidivu,pidivu,0,0,1,0,bcs_f);
+}
+
+void
+Maestro::MakeAbar (const Vector<MultiFab>& state,
+                   Vector<MultiFab>& abar)
+{
+	// timer for profiling
+	BL_PROFILE_VAR("Maestro::MakePiDivu()",MakeAbar);
+
+	for (int lev=0; lev<=finest_level; ++lev) {
+
+		// get references to the MultiFabs at level lev
+		const MultiFab& state_mf = state[lev];
+		MultiFab& abar_mf = abar[lev];
+
+		// Loop over boxes (make sure mfi takes a cell-centered multifab as an argument)
+#ifdef _OPENMP
+#pragma omp parallel
+#endif
+		for ( MFIter mfi(abar_mf, true); mfi.isValid(); ++mfi ) {
+
+			// Get the index space of the valid region
+			const Box& tileBox = mfi.tilebox();
+			const Real* dx = geom[lev].CellSize();
+
+			// call fortran subroutine
+			// use macros in AMReX_ArrayLim.H to pass in each FAB's data,
+			// lo/hi coordinates (including ghost cells), and/or the # of components
+			// We will also pass "validBox", which specifies the "valid" region.
+			make_abar(ARLIM_3D(tileBox.loVect()), ARLIM_3D(tileBox.hiVect()),
+			            BL_TO_FORTRAN_FAB(state_mf[mfi]),
+			            BL_TO_FORTRAN_3D(abar_mf[mfi]));
+		}
+
+	}
+
+	// average down and fill ghost cells
+	AverageDown(abar,0,1);
+	FillPatch(t_old,abar,abar,abar,0,0,1,0,bcs_f);
 }

--- a/Source/Maestro_F.H
+++ b/Source/Maestro_F.H
@@ -739,6 +739,10 @@ extern "C"
                      const amrex::Real* dx,
                      const amrex::Real* pi_cc, const int* p_lo, const int* p_hi, const int* nc,
                      amrex::Real* pidivuw0, const int* d_lo, const int* d_hi);
+
+    void make_abar(const int* lo, const int* hi,
+                 const amrex::Real* state, const int* s_lo, const int* s_hi, const int* nc_s,
+                 amrex::Real* abar, const int* a_lo, const int* a_hi);
 /////////////////////
 
     //////////////////////

--- a/Source/Src_nd/make_plot_variables.F90
+++ b/Source/Src_nd/make_plot_variables.F90
@@ -6,7 +6,7 @@ module plot_variables_module
   use amrex_fort_module, only: amrex_spacedim
   use eos_type_module
   use eos_module
-  use network, only: nspec
+  use network, only: nspec, aion
   use meth_params_module, only: spherical, rho_comp, rhoh_comp, temp_comp, spec_comp, &
        pi_comp, use_pprime_in_tfromp, base_cutoff_density
   ! , pi_comp, &
@@ -1147,5 +1147,34 @@ contains
 
 
   end subroutine make_pidivu
+
+
+  subroutine make_abar(lo,hi,state,s_lo,s_hi,nc_s,abar,a_lo,a_hi) &
+       bind(C,name="make_abar")
+    !
+    ! This routine derives the mass fractions of the species.
+    !
+    integer, intent (in) :: lo(3), hi(3)
+    integer, intent (in) :: s_lo(3), s_hi(3), nc_s
+    integer, intent (in) :: a_lo(3), a_hi(3)
+    double precision, intent(in) :: state(s_lo(1):s_hi(1),s_lo(2):s_hi(2),s_lo(3):s_hi(3),nc_s)
+    double precision, intent (inout) :: abar(a_lo(1):a_hi(1),a_lo(2):a_hi(2),a_lo(3):a_hi(3))
+
+    ! Local variables
+    integer :: i, j, k
+    double precision :: xn(nspec)
+
+    do k=lo(3),hi(3)
+       do j=lo(2),hi(2)
+          do i=lo(1),hi(1)
+             xn(:) = state(i,j,k,spec_comp:spec_comp+nspec-1)/state(i,j,k,rho_comp)
+             abar(i,j,k) = 1.0d0/(sum(xn(:)/aion(:)))
+          enddo
+       enddo
+    enddo
+
+
+
+end subroutine make_abar
 
 end module plot_variables_module


### PR DESCRIPTION
Adds a routine to plot abar - this will be helpful for the small plotfiles where we don't want to output the mass fractions of all the species.