### PR TITLE
Offload burner_loop, make_thermal_coeffs and mk_sponge to gpu

### DIFF
--- a/Exec/Make.Maestro
+++ b/Exec/Make.Maestro
@@ -188,9 +188,11 @@ PROBIN_PARAMETER_DIRS += .
 PROBIN_PARAMETERS := $(shell $(AMREX_HOME)/Tools/F_scripts/findparams.py $(PROBIN_PARAMETER_DIRS))
 
 MANAGED_PROBIN_FLAG :=
-ifdef CUDA
-  ifeq ($(CUDA), t)
+ifdef USE_CUDA
+  ifeq ($(USE_CUDA), TRUE)
+    USE_GPU_PRAGMA = TRUE
     MANAGED_PROBIN_FLAG := --managed
+    DEFINES += -DCUDA 
   endif
 endif
 

--- a/Microphysics/EOS/eos.F90
+++ b/Microphysics/EOS/eos.F90
@@ -116,7 +116,7 @@ contains
     use eos_type_module, only: eos_t, composition, composition_derivatives
     use actual_eos_module, only: actual_eos
     use eos_override_module, only: eos_override
-#ifndef ACC
+#if (!(defined(AMREX_USE_CUDA) || defined(AMREX_USE_ACC)))
     use amrex_error_module, only: amrex_error
 #endif
 
@@ -130,9 +130,9 @@ contains
 
     logical :: has_been_reset
 
-    ! Local variables
+    !$gpu
 
-#ifndef ACC
+#if (!(defined(AMREX_USE_CUDA) || defined(AMREX_USE_ACC)))
     if (.not. initialized) call amrex_error('EOS: not initialized')
 #endif
 
@@ -178,6 +178,8 @@ contains
     integer,      intent(in   ) :: input
     type (eos_t), intent(inout) :: state
     logical,      intent(inout) :: has_been_reset
+
+    !$gpu
 
     ! Reset the input quantities to valid values. For inputs other than rho and T,
     ! this will evolve an EOS call, which will negate the need to do the main EOS call.
@@ -241,6 +243,8 @@ contains
     type (eos_t), intent(inout) :: state
     logical,      intent(inout) :: has_been_reset
 
+    !$gpu
+
     state % rho = min(maxdens, max(mindens, state % rho))
 
   end subroutine reset_rho
@@ -260,6 +264,8 @@ contains
     type (eos_t), intent(inout) :: state
     logical,      intent(inout) :: has_been_reset
 
+    !$gpu
+
     state % T = min(maxtemp, max(mintemp, state % T))
 
   end subroutine reset_T
@@ -276,6 +282,8 @@ contains
 
     type (eos_t), intent(inout) :: state
     logical,      intent(inout) :: has_been_reset
+
+    !$gpu
 
     if (state % e .lt. mine .or. state % e .gt. maxe) then
        call eos_reset(state, has_been_reset)
@@ -296,6 +304,8 @@ contains
     type (eos_t), intent(inout) :: state
     logical,      intent(inout) :: has_been_reset
 
+    !$gpu
+
     if (state % h .lt. minh .or. state % h .gt. maxh) then
        call eos_reset(state, has_been_reset)
     endif
@@ -315,6 +325,8 @@ contains
     type (eos_t), intent(inout) :: state
     logical,      intent(inout) :: has_been_reset
 
+    !$gpu
+
     if (state % s .lt. mins .or. state % s .gt. maxs) then
        call eos_reset(state, has_been_reset)
     endif
@@ -333,6 +345,8 @@ contains
 
     type (eos_t), intent(inout) :: state
     logical,      intent(inout) :: has_been_reset
+
+    !$gpu
 
     if (state % p .lt. minp .or. state % p .gt. maxp) then
        call eos_reset(state, has_been_reset)
@@ -357,6 +371,8 @@ contains
     type (eos_t), intent(inout) :: state
     logical,      intent(inout) :: has_been_reset
 
+    !$gpu
+
     state % T = min(maxtemp, max(mintemp, state % T))
     state % rho = min(maxdens, max(mindens, state % rho))
 
@@ -368,10 +384,8 @@ contains
 
 
 
-#ifndef ACC
+#if (!(defined(AMREX_USE_CUDA) || defined(AMREX_USE_ACC)))
   subroutine check_inputs(input, state)
-
-    !$acc routine seq
 
     use network, only: nspec
     use eos_type_module, only: eos_t, print_state, minx, maxx, minye, maxye, &
@@ -453,8 +467,6 @@ contains
 
   subroutine check_rho(state)
 
-    !$acc routine seq
-
     use eos_type_module, only: eos_t, mindens, maxdens, print_state
 
     implicit none
@@ -474,8 +486,6 @@ contains
 
 
   subroutine check_T(state)
-
-    !$acc routine seq
 
     use eos_type_module, only: eos_t, mintemp, maxtemp, print_state
 
@@ -497,8 +507,6 @@ contains
 
   subroutine check_e(state)
 
-    !$acc routine seq
-
     use eos_type_module, only: eos_t, mine, maxe, print_state
 
     implicit none
@@ -518,8 +526,6 @@ contains
 
 
   subroutine check_h(state)
-
-    !$acc routine seq
 
     use eos_type_module, only: eos_t, minh, maxh, print_state
 
@@ -541,8 +547,6 @@ contains
 
   subroutine check_s(state)
 
-    !$acc routine seq
-
     use eos_type_module, only: eos_t, mins, maxs, print_state
 
     implicit none
@@ -562,8 +566,6 @@ contains
 
 
   subroutine check_p(state)
-
-    !$acc routine seq
 
     use eos_type_module, only: eos_t, minp, maxp, print_state
 

--- a/Microphysics/EOS/eos_override.F90
+++ b/Microphysics/EOS/eos_override.F90
@@ -18,6 +18,8 @@ contains
 
     type (eos_t) :: state
 
+    !$gpu
+
   end subroutine eos_override
 
 end module eos_override_module

--- a/Microphysics/conductivity/conductivity.F90
+++ b/Microphysics/conductivity/conductivity.F90
@@ -37,6 +37,8 @@ contains
     integer       , intent(in   ) :: input
     type (eos_t)  , intent(inout) :: state
 
+    !$gpu
+
     ! call the EOS, passing through the arguments we called conducteos with
     call eos(input, state)
 

--- a/Microphysics/conductivity/constant/Make.package
+++ b/Microphysics/conductivity/constant/Make.package
@@ -1,3 +1,1 @@
-f90EXE_sources += constant_conductivity.f90
-
-
+F90EXE_sources += constant_conductivity.F90

--- a/Microphysics/conductivity/constant/constant_conductivity.F90
+++ b/Microphysics/conductivity/constant/constant_conductivity.F90
@@ -1,8 +1,8 @@
 module actual_conductivity_module
 
-  use amrex_fort_module, only : rt => amrex_real                                
+  use amrex_fort_module, only : rt => amrex_real
   use eos_type_module, only : eos_t
-  
+
   implicit none
 
 contains
@@ -14,15 +14,17 @@ contains
   end subroutine actual_conductivity_init
 
   subroutine actual_conductivity(eos_state)
-    
+
     use extern_probin_module, only: const_conductivity
 
     implicit none
 
     type (eos_t), intent(inout) :: eos_state
 
+    !$gpu
+
     eos_state % conductivity = const_conductivity
-    
+
   end subroutine actual_conductivity
 
 end module actual_conductivity_module

--- a/Microphysics/networks/Make.package
+++ b/Microphysics/networks/Make.package
@@ -1,4 +1,4 @@
-f90EXE_sources += network.f90
+F90EXE_sources += network.F90
 
 ifeq ($(USE_REACT),TRUE)
 F90EXE_sources += burner.F90

--- a/Microphysics/networks/burner.F90
+++ b/Microphysics/networks/burner.F90
@@ -61,7 +61,7 @@ contains
 
     ! Initialize the final state by assuming it does not change.
 
-    state_out = state_in
+    call copy_burn_t(state_out, state_in)
 
     ! Do the burning.
 

--- a/Microphysics/networks/burner.F90
+++ b/Microphysics/networks/burner.F90
@@ -43,11 +43,13 @@ contains
 
     double precision :: time
 
+    !$gpu
+
     time = 0.d0
 
     ! Make sure the network and burner have been initialized.
 
-#ifndef ACC
+#if !defined(ACC) && !defined(AMREX_USE_CUDA)
     if (.NOT. network_initialized) then
        call amrex_error("ERROR in burner: must initialize network first.")
     endif

--- a/Microphysics/networks/general_null/Make.package
+++ b/Microphysics/networks/general_null/Make.package
@@ -1,24 +1,24 @@
-f90EXE_sources += actual_network.f90
+F90EXE_sources += actual_network.F90
 
 ifeq ($(USE_REACT),TRUE)
 ifneq ($(USE_SDC), TRUE)
-f90EXE_sources += actual_burner.f90
+F90EXE_sources += actual_burner.F90
 endif
-f90EXE_sources += actual_rhs.f90
+F90EXE_sources += actual_rhs.F90
 endif
 
-# actual_network.f90 is created at build time for this network
-actual_network.f90:   $(GENERAL_NET_INPUTS) $(MAESTROEX_HOME)/Microphysics/networks/general_null/network.template
+# actual_network.F90 is created at build time for this network
+actual_network.F90:   $(GENERAL_NET_INPUTS) $(MAESTROEX_HOME)/Microphysics/networks/general_null/network.template
 	@echo " "
 	@echo "---------------------------------------------------------------------------"
-	@echo "WRITING actual_network.f90:"
+	@echo "WRITING actual_network.F90:"
 	$(MAESTROEX_HOME)/Microphysics/networks/general_null/write_network.py \
             -t $(MAESTROEX_HOME)/Microphysics/networks/general_null/network.template \
             -s $(GENERAL_NET_INPUTS) \
-            -o actual_network.f90
+            -o actual_network.F90
 	@echo "---------------------------------------------------------------------------"
 	@echo " "
 
-# remove actual_network.f90 for 'make clean' and therefore 'make realclean'
+# remove actual_network.F90 for 'make clean' and therefore 'make realclean'
 clean::
-	$(RM) actual_network.f90
+	$(RM) actual_network.F90

--- a/Microphysics/networks/general_null/actual_burner.F90
+++ b/Microphysics/networks/general_null/actual_burner.F90
@@ -21,6 +21,8 @@ contains
     type (burn_t), intent(inout) :: state_out
     double precision, intent(in) :: dt, time
 
+    !$gpu
+
     ! Do nothing in this burner.
 
   end subroutine actual_burner

--- a/Microphysics/networks/general_null/actual_rhs.F90
+++ b/Microphysics/networks/general_null/actual_rhs.F90
@@ -23,6 +23,8 @@ contains
 
     type (burn_t) :: state
 
+    !$gpu
+
     ! Do nothing in this RHS.
 
     state % ydot = ZERO
@@ -42,6 +44,8 @@ contains
 
     type (burn_t) :: state
 
+    !$gpu
+
     ! Do nothing in this RHS.
 
     state % jac(:,:) = ZERO
@@ -59,6 +63,8 @@ contains
     implicit none
 
     type (burn_t)    :: state
+
+    !$gpu
 
   end subroutine update_unevolved_species
 

--- a/Microphysics/networks/general_null/network.template
+++ b/Microphysics/networks/general_null/network.template
@@ -27,14 +27,22 @@ module actual_network
   character (len=16), save :: aux_names(naux)
   character (len= 5), save :: short_aux_names(naux)
 
-  double precision, save   :: aion(nspec), zion(nspec)
+  double precision, allocatable, save   :: aion(:), zion(:)
 
   integer, parameter :: nrates = 1
   integer, parameter :: num_rate_groups = 1
 
+#ifdef AMREX_USE_CUDA
+  attributes(managed) :: aion
+  attributes(managed) :: zion
+#endif
+
 contains
 
   subroutine actual_network_init
+
+    allocate(aion(nspec))
+    allocate(zion(nspec))
 
     @@SPEC_NAMES@@
 

--- a/Microphysics/networks/network.F90
+++ b/Microphysics/networks/network.F90
@@ -31,9 +31,13 @@ module network
   logical :: network_initialized = .false.
 
   ! this will be computed here, not in the actual network
-  real(kind=rt) :: aion_inv(nspec)
+  real(kind=rt), allocatable :: aion_inv(:)
 
   !$acc declare create(aion_inv)
+
+#ifdef AMREX_USE_CUDA
+  attributes(managed) :: aion_inv
+#endif
 
 contains
 
@@ -43,6 +47,8 @@ contains
     use amrex_constants_module, only : ONE
 
     implicit none
+
+    allocate(aion_inv(nspec))
 
     ! First, we call the specific network initialization.
     ! This should set the number of species and number of

--- a/Source/MaestroAdvance.cpp
+++ b/Source/MaestroAdvance.cpp
@@ -21,12 +21,12 @@ Maestro::AdvanceTimeStep (bool is_initIter) {
 
 // HACK
     base_time_start = ParallelDescriptor::second();
-    
+
     base_time += ParallelDescriptor::second() - base_time_start;
     ParallelDescriptor::ReduceRealMax(base_time,ParallelDescriptor::IOProcessorNumber());
     ParallelDescriptor::Bcast(&base_time,1,ParallelDescriptor::IOProcessorNumber());
 
-    
+
     misc_time_start = ParallelDescriptor::second();
 
     // features to be added later:
@@ -203,7 +203,7 @@ Maestro::AdvanceTimeStep (bool is_initIter) {
         init_sponge(rho0_old.dataPtr());
         MakeSponge(sponge);
     }
-    
+
     misc_time += ParallelDescriptor::second() - misc_time_start;
     ParallelDescriptor::ReduceRealMax(misc_time,ParallelDescriptor::IOProcessorNumber());
     ParallelDescriptor::Bcast(&misc_time,1,ParallelDescriptor::IOProcessorNumber());
@@ -213,13 +213,13 @@ Maestro::AdvanceTimeStep (bool is_initIter) {
     //////////////////////////////////////////////////////////////////////////////
 
     react_time_start = ParallelDescriptor::second();
-    
+
     if (maestro_verbose >= 1) {
         Print() << "<<< STEP 1 : react state >>>" << std::endl;
     }
 
     React(sold,s1,rho_Hext,rho_omegadot,rho_Hnuc,p0_old,0.5*dt);
-    
+
     react_time += ParallelDescriptor::second() - react_time_start;
     ParallelDescriptor::ReduceRealMax(react_time,ParallelDescriptor::IOProcessorNumber());
     ParallelDescriptor::Bcast(&react_time,1,ParallelDescriptor::IOProcessorNumber());
@@ -229,7 +229,7 @@ Maestro::AdvanceTimeStep (bool is_initIter) {
     //////////////////////////////////////////////////////////////////////////////
 
     advect_time_start = ParallelDescriptor::second();
-    
+
     if (maestro_verbose >= 1) {
         Print() << "<<< STEP 2 : make w0 >>>" << std::endl;
     }
@@ -303,7 +303,7 @@ Maestro::AdvanceTimeStep (bool is_initIter) {
         w0_old = w0;
 
         base_time_start = ParallelDescriptor::second();
-    
+
         // compute w0, w0_force, and delta_chi_w0
         is_predictor = 1;
         make_w0(w0.dataPtr(),w0_old.dataPtr(),w0_force.dataPtr(),Sbar.dataPtr(),
@@ -311,7 +311,7 @@ Maestro::AdvanceTimeStep (bool is_initIter) {
                 gamma1bar_old.dataPtr(),gamma1bar_old.dataPtr(),p0_minus_peosbar.dataPtr(),
                 etarho_ec.dataPtr(),etarho_cc.dataPtr(),delta_chi_w0.dataPtr(),
                 r_cc_loc.dataPtr(),r_edge_loc.dataPtr(),&dt,&dtold,&is_predictor);
-    
+
         base_time += ParallelDescriptor::second() - base_time_start;
         ParallelDescriptor::ReduceRealMax(base_time,ParallelDescriptor::IOProcessorNumber());
         ParallelDescriptor::Bcast(&base_time,1,ParallelDescriptor::IOProcessorNumber());
@@ -360,7 +360,7 @@ Maestro::AdvanceTimeStep (bool is_initIter) {
     ParallelDescriptor::Bcast(&advect_time,1,ParallelDescriptor::IOProcessorNumber());
 
     macproj_time_start = ParallelDescriptor::second();
-    
+
     // MAC projection
     // includes spherical option in C++ function
     MacProj(umac,macphi,macrhs,beta0_old,is_predictor);
@@ -368,26 +368,26 @@ Maestro::AdvanceTimeStep (bool is_initIter) {
     macproj_time += ParallelDescriptor::second() - macproj_time_start;
     ParallelDescriptor::ReduceRealMax(macproj_time,ParallelDescriptor::IOProcessorNumber());
     ParallelDescriptor::Bcast(&macproj_time,1,ParallelDescriptor::IOProcessorNumber());
-    
+
     //////////////////////////////////////////////////////////////////////////////
     // STEP 4 -- advect the base state and full state through dt
     //////////////////////////////////////////////////////////////////////////////
 
     advect_time_start = ParallelDescriptor::second();
-    
+
     if (maestro_verbose >= 1) {
         Print() << "<<< STEP 4 : advect base >>>" << std::endl;
     }
 
     // advect the base state density
     if (evolve_base_state) {
-        
+
         base_time_start = ParallelDescriptor::second();
 
         advect_base_dens(w0.dataPtr(), rho0_old.dataPtr(), rho0_new.dataPtr(),
-                         rho0_predicted_edge.dataPtr(), &dt,
+                         rho0_predicted_edge.dataPtr(), dt,
                          r_cc_loc.dataPtr(), r_edge_loc.dataPtr());
-    
+
         base_time += ParallelDescriptor::second() - base_time_start;
         ParallelDescriptor::ReduceRealMax(base_time,ParallelDescriptor::IOProcessorNumber());
         ParallelDescriptor::Bcast(&base_time,1,ParallelDescriptor::IOProcessorNumber());
@@ -447,7 +447,7 @@ Maestro::AdvanceTimeStep (bool is_initIter) {
             } else {
                 MakeEtarhoSphr(s1,s2,umac,w0mac,etarho_ec,etarho_cc);
             }
-            
+
             // correct the base state density by "averaging"
             Average(s2, rho0_new, Rho);
             compute_cutoff_coords(rho0_new.dataPtr());
@@ -460,7 +460,7 @@ Maestro::AdvanceTimeStep (bool is_initIter) {
                        rho0_new.dataPtr(),
                        r_cc_loc.dataPtr(),
                        r_edge_loc.dataPtr());
-    
+
         base_time += ParallelDescriptor::second() - base_time_start;
         ParallelDescriptor::ReduceRealMax(base_time,ParallelDescriptor::IOProcessorNumber());
         ParallelDescriptor::Bcast(&base_time,1,ParallelDescriptor::IOProcessorNumber());
@@ -470,13 +470,13 @@ Maestro::AdvanceTimeStep (bool is_initIter) {
         p0_new = p0_old;
 
         base_time_start = ParallelDescriptor::second();
-    
+
         enforce_HSE(rho0_new.dataPtr(),
                     p0_new.dataPtr(),
                     grav_cell_new.dataPtr(),
                     r_cc_loc.dataPtr(),
                     r_edge_loc.dataPtr());
-    
+
         base_time += ParallelDescriptor::second() - base_time_start;
         ParallelDescriptor::ReduceRealMax(base_time,ParallelDescriptor::IOProcessorNumber());
         ParallelDescriptor::Bcast(&base_time,1,ParallelDescriptor::IOProcessorNumber());
@@ -516,12 +516,12 @@ Maestro::AdvanceTimeStep (bool is_initIter) {
         Average(s1, rhoh0_old, RhoH);
 
         base_time_start = ParallelDescriptor::second();
-    
+
         advect_base_enthalpy(w0.dataPtr(), rho0_old.dataPtr(),
                              rhoh0_old.dataPtr(), rhoh0_new.dataPtr(),
-                             rho0_predicted_edge.dataPtr(), psi.dataPtr(), &dt,
+                             rho0_predicted_edge.dataPtr(), psi.dataPtr(), dt,
                              r_cc_loc.dataPtr(), r_edge_loc.dataPtr());
-        
+
         base_time += ParallelDescriptor::second() - base_time_start;
         ParallelDescriptor::ReduceRealMax(base_time,ParallelDescriptor::IOProcessorNumber());
         ParallelDescriptor::Bcast(&base_time,1,ParallelDescriptor::IOProcessorNumber());
@@ -541,13 +541,13 @@ Maestro::AdvanceTimeStep (bool is_initIter) {
     advect_time += ParallelDescriptor::second() - advect_time_start;
     ParallelDescriptor::ReduceRealMax(advect_time,ParallelDescriptor::IOProcessorNumber());
     ParallelDescriptor::Bcast(&advect_time,1,ParallelDescriptor::IOProcessorNumber());
-    
+
     //////////////////////////////////////////////////////////////////////////////
     // STEP 4a (Option I) -- Add thermal conduction (only enthalpy terms)
     //////////////////////////////////////////////////////////////////////////////
 
     thermal_time_start = ParallelDescriptor::second();
-    
+
     if (maestro_verbose >= 1) {
         Print() << "<<< STEP 4a: thermal conduct >>>" << std::endl;
     }
@@ -559,9 +559,9 @@ Maestro::AdvanceTimeStep (bool is_initIter) {
     thermal_time += ParallelDescriptor::second() - thermal_time_start;
     ParallelDescriptor::ReduceRealMax(thermal_time,ParallelDescriptor::IOProcessorNumber());
     ParallelDescriptor::Bcast(&thermal_time,1,ParallelDescriptor::IOProcessorNumber());
-    
+
     misc_time_start = ParallelDescriptor::second();
-    
+
     // pass temperature through for seeding the temperature update eos call
     // pi goes along for the ride
     for (int lev=0; lev<=finest_level; ++lev) {
@@ -588,29 +588,29 @@ Maestro::AdvanceTimeStep (bool is_initIter) {
     misc_time += ParallelDescriptor::second() - misc_time_start;
     ParallelDescriptor::ReduceRealMax(misc_time,ParallelDescriptor::IOProcessorNumber());
     ParallelDescriptor::Bcast(&misc_time,1,ParallelDescriptor::IOProcessorNumber());
-    
+
     //////////////////////////////////////////////////////////////////////////////
     // STEP 5 -- react the full state and then base state through dt/2
     //////////////////////////////////////////////////////////////////////////////
 
     react_time_start = ParallelDescriptor::second();
-    
+
     if (maestro_verbose >= 1) {
         Print() << "<<< STEP 5 : react state >>>" << std::endl;
     }
-    
+
     React(s2,snew,rho_Hext,rho_omegadot,rho_Hnuc,p0_new,0.5*dt);
 
     react_time += ParallelDescriptor::second() - react_time_start;
     ParallelDescriptor::ReduceRealMax(react_time,ParallelDescriptor::IOProcessorNumber());
     ParallelDescriptor::Bcast(&react_time,1,ParallelDescriptor::IOProcessorNumber());
-    
+
     misc_time_start = ParallelDescriptor::second();
-    
+
     if (evolve_base_state) {
         // compute beta0 and gamma1bar
         MakeGamma1bar(snew,gamma1bar_new,p0_new);
-        
+
         base_time_start = ParallelDescriptor::second();
 
         make_beta0(beta0_new.dataPtr(), rho0_new.dataPtr(), p0_new.dataPtr(),
@@ -633,13 +633,13 @@ Maestro::AdvanceTimeStep (bool is_initIter) {
     misc_time += ParallelDescriptor::second() - misc_time_start;
     ParallelDescriptor::ReduceRealMax(misc_time,ParallelDescriptor::IOProcessorNumber());
     ParallelDescriptor::Bcast(&misc_time,1,ParallelDescriptor::IOProcessorNumber());
-    
+
     //////////////////////////////////////////////////////////////////////////////
     // STEP 6 -- define a new average expansion rate at n+1/2
     //////////////////////////////////////////////////////////////////////////////
 
     advect_time_start = ParallelDescriptor::second();
-    
+
     if (maestro_verbose >= 1) {
         Print() << "<<< STEP 6 : make new S and new w0 >>>" << std::endl;
     }
@@ -717,13 +717,13 @@ Maestro::AdvanceTimeStep (bool is_initIter) {
         is_predictor = 0;
 
         base_time_start = ParallelDescriptor::second();
-        
+
         make_w0(w0.dataPtr(),w0_old.dataPtr(),w0_force.dataPtr(),Sbar.dataPtr(),
                 rho0_old.dataPtr(),rho0_new.dataPtr(),p0_old.dataPtr(),p0_new.dataPtr(),
                 gamma1bar_old.dataPtr(),gamma1bar_new.dataPtr(),p0_minus_peosbar.dataPtr(),
                 etarho_ec.dataPtr(),etarho_cc.dataPtr(),delta_chi_w0.dataPtr(),
                 r_cc_loc.dataPtr(),r_edge_loc.dataPtr(),&dt,&dtold,&is_predictor);
-    
+
         base_time += ParallelDescriptor::second() - base_time_start;
         ParallelDescriptor::ReduceRealMax(base_time,ParallelDescriptor::IOProcessorNumber());
         ParallelDescriptor::Bcast(&base_time,1,ParallelDescriptor::IOProcessorNumber());
@@ -752,13 +752,13 @@ Maestro::AdvanceTimeStep (bool is_initIter) {
     // compute RHS for MAC projection, beta0*(S_cc-Sbar) + beta0*delta_chi
     MakeRHCCforMacProj(macrhs,rho0_new,S_cc_nph,Sbar,beta0_nph,delta_gamma1_term,
                        gamma1bar_new,p0_new,delta_p_term,delta_chi,is_predictor);
-    
+
     advect_time += ParallelDescriptor::second() - advect_time_start;
     ParallelDescriptor::ReduceRealMax(advect_time,ParallelDescriptor::IOProcessorNumber());
     ParallelDescriptor::Bcast(&advect_time,1,ParallelDescriptor::IOProcessorNumber());
-    
+
     macproj_time_start = ParallelDescriptor::second();
-    
+
     // MAC projection
     // includes spherical option in C++ function
     MacProj(umac,macphi,macrhs,beta0_nph,is_predictor);
@@ -766,13 +766,13 @@ Maestro::AdvanceTimeStep (bool is_initIter) {
     macproj_time += ParallelDescriptor::second() - macproj_time_start;
     ParallelDescriptor::ReduceRealMax(macproj_time,ParallelDescriptor::IOProcessorNumber());
     ParallelDescriptor::Bcast(&macproj_time,1,ParallelDescriptor::IOProcessorNumber());
-    
+
     //////////////////////////////////////////////////////////////////////////////
     // STEP 8 -- advect the base state and full state through dt
     //////////////////////////////////////////////////////////////////////////////
 
     advect_time_start = ParallelDescriptor::second();
-    
+
     if (maestro_verbose >= 1) {
         Print() << "<<< STEP 8 : advect base >>>" << std::endl;
     }
@@ -780,11 +780,11 @@ Maestro::AdvanceTimeStep (bool is_initIter) {
     // advect the base state density
     if (evolve_base_state) {
         base_time_start = ParallelDescriptor::second();
-        
+
         advect_base_dens(w0.dataPtr(), rho0_old.dataPtr(), rho0_new.dataPtr(),
-                         rho0_predicted_edge.dataPtr(), &dt,
+                         rho0_predicted_edge.dataPtr(), dt,
                          r_cc_loc.dataPtr(), r_edge_loc.dataPtr());
-    
+
         base_time += ParallelDescriptor::second() - base_time_start;
         ParallelDescriptor::ReduceRealMax(base_time,ParallelDescriptor::IOProcessorNumber());
         ParallelDescriptor::Bcast(&base_time,1,ParallelDescriptor::IOProcessorNumber());
@@ -826,7 +826,7 @@ Maestro::AdvanceTimeStep (bool is_initIter) {
             Average(s2, rho0_new, Rho);
             compute_cutoff_coords(rho0_new.dataPtr());
         }
-    
+
         // update grav_cell_new, rho0_nph, grav_cell_nph
         base_time_start = ParallelDescriptor::second();
 
@@ -843,23 +843,23 @@ Maestro::AdvanceTimeStep (bool is_initIter) {
                        rho0_nph.dataPtr(),
                        r_cc_loc.dataPtr(),
                        r_edge_loc.dataPtr());
-    
+
         base_time += ParallelDescriptor::second() - base_time_start;
         ParallelDescriptor::ReduceRealMax(base_time,ParallelDescriptor::IOProcessorNumber());
         ParallelDescriptor::Bcast(&base_time,1,ParallelDescriptor::IOProcessorNumber());
-        
+
         // base state pressure update
         // set new p0 through HSE
         p0_new = p0_old;
 
         base_time_start = ParallelDescriptor::second();
-        
+
         enforce_HSE(rho0_new.dataPtr(),
                     p0_new.dataPtr(),
                     grav_cell_new.dataPtr(),
                     r_cc_loc.dataPtr(),
                     r_edge_loc.dataPtr());
-    
+
         base_time += ParallelDescriptor::second() - base_time_start;
         ParallelDescriptor::ReduceRealMax(base_time,ParallelDescriptor::IOProcessorNumber());
         ParallelDescriptor::Bcast(&base_time,1,ParallelDescriptor::IOProcessorNumber());
@@ -877,7 +877,7 @@ Maestro::AdvanceTimeStep (bool is_initIter) {
             MakeGamma1bar(s2, gamma1bar_temp2, p0_new);
 
             base_time_start = ParallelDescriptor::second();
-            
+
             // compute gamma1bar^{nph} and store it in gamma1bar_temp2
             for (int i=0; i<gamma1bar_temp2.size(); ++i) {
                 gamma1bar_temp2[i] = 0.5*(gamma1bar_temp1[i] + gamma1bar_temp2[i]);
@@ -888,20 +888,20 @@ Maestro::AdvanceTimeStep (bool is_initIter) {
                                Sbar.dataPtr(),
                                r_cc_loc.dataPtr(),
                                r_edge_loc.dataPtr());
-    
+
             base_time += ParallelDescriptor::second() - base_time_start;
             ParallelDescriptor::ReduceRealMax(base_time,ParallelDescriptor::IOProcessorNumber());
             ParallelDescriptor::Bcast(&base_time,1,ParallelDescriptor::IOProcessorNumber());
         }
-        
+
         base_time_start = ParallelDescriptor::second();
 
         // base state enthalpy update
         advect_base_enthalpy(w0.dataPtr(), rho0_old.dataPtr(),
                              rhoh0_old.dataPtr(), rhoh0_new.dataPtr(),
-                             rho0_predicted_edge.dataPtr(), psi.dataPtr(), &dt,
+                             rho0_predicted_edge.dataPtr(), psi.dataPtr(), dt,
                              r_cc_loc.dataPtr(), r_edge_loc.dataPtr());
-    
+
         base_time += ParallelDescriptor::second() - base_time_start;
         ParallelDescriptor::ReduceRealMax(base_time,ParallelDescriptor::IOProcessorNumber());
         ParallelDescriptor::Bcast(&base_time,1,ParallelDescriptor::IOProcessorNumber());
@@ -920,13 +920,13 @@ Maestro::AdvanceTimeStep (bool is_initIter) {
     advect_time += ParallelDescriptor::second() - advect_time_start;
     ParallelDescriptor::ReduceRealMax(advect_time,ParallelDescriptor::IOProcessorNumber());
     ParallelDescriptor::Bcast(&advect_time,1,ParallelDescriptor::IOProcessorNumber());
-    
+
     //////////////////////////////////////////////////////////////////////////////
     // STEP 8a (Option I) -- Add thermal conduction (only enthalpy terms)
     //////////////////////////////////////////////////////////////////////////////
 
     thermal_time_start = ParallelDescriptor::second();
-    
+
     if (maestro_verbose >= 1) {
         Print() << "<<< STEP 8a: thermal conduct >>>" << std::endl;
     }
@@ -940,9 +940,9 @@ Maestro::AdvanceTimeStep (bool is_initIter) {
     thermal_time += ParallelDescriptor::second() - thermal_time_start;
     ParallelDescriptor::ReduceRealMax(thermal_time,ParallelDescriptor::IOProcessorNumber());
     ParallelDescriptor::Bcast(&thermal_time,1,ParallelDescriptor::IOProcessorNumber());
-    
+
     misc_time_start = ParallelDescriptor::second();
-    
+
     // pass temperature through for seeding the temperature update eos call
     // pi goes along for the ride
     for (int lev=0; lev<=finest_level; ++lev) {
@@ -957,21 +957,21 @@ Maestro::AdvanceTimeStep (bool is_initIter) {
     else {
         TfromRhoH(s2,p0_new);
     }
-    
+
     misc_time += ParallelDescriptor::second() - misc_time_start;
     ParallelDescriptor::ReduceRealMax(misc_time,ParallelDescriptor::IOProcessorNumber());
     ParallelDescriptor::Bcast(&misc_time,1,ParallelDescriptor::IOProcessorNumber());
-    
+
     //////////////////////////////////////////////////////////////////////////////
     // STEP 9 -- react the full state and then base state through dt/2
     //////////////////////////////////////////////////////////////////////////////
 
     react_time_start = ParallelDescriptor::second();
-    
+
     if (maestro_verbose >= 1) {
         Print() << "<<< STEP 9 : react state >>>" << std::endl;
     }
-    
+
     React(s2,snew,rho_Hext,rho_omegadot,rho_Hnuc,p0_new,0.5*dt);
 
     react_time += ParallelDescriptor::second() - react_time_start;
@@ -979,7 +979,7 @@ Maestro::AdvanceTimeStep (bool is_initIter) {
     ParallelDescriptor::Bcast(&react_time,1,ParallelDescriptor::IOProcessorNumber());
 
     misc_time_start = ParallelDescriptor::second();
-    
+
     if (evolve_base_state) {
         // compute beta0 and gamma1bar
         MakeGamma1bar(snew,gamma1bar_new,p0_new);
@@ -988,7 +988,7 @@ Maestro::AdvanceTimeStep (bool is_initIter) {
 
         make_beta0(beta0_new.dataPtr(), rho0_new.dataPtr(), p0_new.dataPtr(),
                    gamma1bar_new.dataPtr(), grav_cell_new.dataPtr());
-    
+
         base_time += ParallelDescriptor::second() - base_time_start;
         ParallelDescriptor::ReduceRealMax(base_time,ParallelDescriptor::IOProcessorNumber());
         ParallelDescriptor::Bcast(&base_time,1,ParallelDescriptor::IOProcessorNumber());
@@ -997,7 +997,7 @@ Maestro::AdvanceTimeStep (bool is_initIter) {
     for(int i=0; i<beta0_nph.size(); ++i) {
         beta0_nph[i] = 0.5*(beta0_old[i]+beta0_new[i]);
     }
-    
+
     misc_time += ParallelDescriptor::second() - misc_time_start;
     ParallelDescriptor::ReduceRealMax(misc_time,ParallelDescriptor::IOProcessorNumber());
     ParallelDescriptor::Bcast(&misc_time,1,ParallelDescriptor::IOProcessorNumber());
@@ -1007,7 +1007,7 @@ Maestro::AdvanceTimeStep (bool is_initIter) {
     //////////////////////////////////////////////////////////////////////////////
 
     ndproj_time_start = ParallelDescriptor::second();
-    
+
     if (maestro_verbose >= 1) {
         Print() << "<<< STEP 10: make new S >>>" << std::endl;
     }
@@ -1041,13 +1041,13 @@ Maestro::AdvanceTimeStep (bool is_initIter) {
     ndproj_time += ParallelDescriptor::second() - ndproj_time_start;
     ParallelDescriptor::ReduceRealMax(ndproj_time,ParallelDescriptor::IOProcessorNumber());
     ParallelDescriptor::Bcast(&ndproj_time,1,ParallelDescriptor::IOProcessorNumber());
-    
+
     //////////////////////////////////////////////////////////////////////////////
     // STEP 11 -- update the velocity
     //////////////////////////////////////////////////////////////////////////////
 
     advect_time_start = ParallelDescriptor::second();
-    
+
     if (maestro_verbose >= 1) {
         Print() << "<<< STEP 11: update and project new velocity >>>" << std::endl;
     }
@@ -1064,11 +1064,11 @@ Maestro::AdvanceTimeStep (bool is_initIter) {
     }
 
     int proj_type;
-    
+
     advect_time += ParallelDescriptor::second() - advect_time_start;
     ParallelDescriptor::ReduceRealMax(advect_time,ParallelDescriptor::IOProcessorNumber());
     ParallelDescriptor::Bcast(&advect_time,1,ParallelDescriptor::IOProcessorNumber());
-    
+
     ndproj_time_start = ParallelDescriptor::second();
 
     // Project the new velocity field
@@ -1128,13 +1128,13 @@ Maestro::AdvanceTimeStep (bool is_initIter) {
     for(int i=0; i<beta0_nm1.size(); ++i) {
         beta0_nm1[i] = 0.5*(beta0_old[i]+beta0_new[i]);
     }
-    
+
     ndproj_time += ParallelDescriptor::second() - ndproj_time_start;
     ParallelDescriptor::ReduceRealMax(ndproj_time,ParallelDescriptor::IOProcessorNumber());
     ParallelDescriptor::Bcast(&ndproj_time,1,ParallelDescriptor::IOProcessorNumber());
 
     misc_time_start = ParallelDescriptor::second();
-    
+
     if (!is_initIter) {
         if (!fix_base_state) {
             // compute tempbar by "averaging"
@@ -1144,11 +1144,11 @@ Maestro::AdvanceTimeStep (bool is_initIter) {
 
     Print() << "\nTimestep " << istep << " ends with TIME = " << t_new
             << " DT = " << dt << std::endl;
-    
+
     misc_time += ParallelDescriptor::second() - misc_time_start;
     ParallelDescriptor::ReduceRealMax(misc_time,ParallelDescriptor::IOProcessorNumber());
     ParallelDescriptor::Bcast(&misc_time,1,ParallelDescriptor::IOProcessorNumber());
-    
+
     // print wallclock time
     if (maestro_verbose > 0) {
         Print() << "Timing summary:\n";

--- a/Source/MaestroReact.cpp
+++ b/Source/MaestroReact.cpp
@@ -148,14 +148,15 @@ void Maestro::Burner(const Vector<MultiFab>& s_in,
             // lo/hi coordinates (including ghost cells), and/or the # of components
             // We will also pass "validBox", which specifies the "valid" region.
             if (spherical == 1) {
-                burner_loop_sphr(ARLIM_3D(tileBox.loVect()), ARLIM_3D(tileBox.hiVect()),
-                                 BL_TO_FORTRAN_FAB(s_in_mf[mfi]),
-                                 BL_TO_FORTRAN_FAB(s_out_mf[mfi]),
-                                 BL_TO_FORTRAN_3D(rho_Hext_mf[mfi]),
-                                 BL_TO_FORTRAN_FAB(rho_omegadot_mf[mfi]),
-                                 BL_TO_FORTRAN_3D(rho_Hnuc_mf[mfi]),
-                                 BL_TO_FORTRAN_3D(tempbar_cart_mf[mfi]), dt_in,
-                                 BL_TO_FORTRAN_3D(mask[mfi]), use_mask);
+#pragma gpu box(tileBox)
+                burner_loop_sphr(AMREX_INT_ANYD(tileBox.loVect()), AMREX_INT_ANYD(tileBox.hiVect()),
+                                 BL_TO_FORTRAN_ANYD(s_in_mf[mfi]),
+                                 BL_TO_FORTRAN_ANYD(s_out_mf[mfi]),
+                                 BL_TO_FORTRAN_ANYD(rho_Hext_mf[mfi]),
+                                 BL_TO_FORTRAN_ANYD(rho_omegadot_mf[mfi]),
+                                 BL_TO_FORTRAN_ANYD(rho_Hnuc_mf[mfi]),
+                                 BL_TO_FORTRAN_ANYD(tempbar_cart_mf[mfi]), dt_in,
+                                 BL_TO_FORTRAN_ANYD(mask[mfi]), use_mask);
             } else {
 #pragma gpu box(tileBox)
                 burner_loop(AMREX_INT_ANYD(tileBox.loVect()), AMREX_INT_ANYD(tileBox.hiVect()),

--- a/Source/MaestroReact.cpp
+++ b/Source/MaestroReact.cpp
@@ -150,10 +150,10 @@ void Maestro::Burner(const Vector<MultiFab>& s_in,
             if (spherical == 1) {
 #pragma gpu box(tileBox)
                 burner_loop_sphr(AMREX_INT_ANYD(tileBox.loVect()), AMREX_INT_ANYD(tileBox.hiVect()),
-                                 BL_TO_FORTRAN_ANYD(s_in_mf[mfi]),
-                                 BL_TO_FORTRAN_ANYD(s_out_mf[mfi]),
+                                 BL_TO_FORTRAN_FAB(s_in_mf[mfi]),
+                                 BL_TO_FORTRAN_FAB(s_out_mf[mfi]),
                                  BL_TO_FORTRAN_ANYD(rho_Hext_mf[mfi]),
-                                 BL_TO_FORTRAN_ANYD(rho_omegadot_mf[mfi]),
+                                 BL_TO_FORTRAN_FAB(rho_omegadot_mf[mfi]),
                                  BL_TO_FORTRAN_ANYD(rho_Hnuc_mf[mfi]),
                                  BL_TO_FORTRAN_ANYD(tempbar_cart_mf[mfi]), dt_in,
                                  BL_TO_FORTRAN_ANYD(mask[mfi]), use_mask);

--- a/Source/MaestroReact.cpp
+++ b/Source/MaestroReact.cpp
@@ -161,10 +161,10 @@ void Maestro::Burner(const Vector<MultiFab>& s_in,
 #pragma gpu box(tileBox)
                 burner_loop(AMREX_INT_ANYD(tileBox.loVect()), AMREX_INT_ANYD(tileBox.hiVect()),
                             lev,
-                            BL_TO_FORTRAN_ANYD(s_in_mf[mfi]),
-                            BL_TO_FORTRAN_ANYD(s_out_mf[mfi]),
+                            BL_TO_FORTRAN_FAB(s_in_mf[mfi]),
+                            BL_TO_FORTRAN_FAB(s_out_mf[mfi]),
                             BL_TO_FORTRAN_ANYD(rho_Hext_mf[mfi]),
-                            BL_TO_FORTRAN_ANYD(rho_omegadot_mf[mfi]),
+                            BL_TO_FORTRAN_FAB(rho_omegadot_mf[mfi]),
                             BL_TO_FORTRAN_ANYD(rho_Hnuc_mf[mfi]),
                             tempbar_init.dataPtr(), dt_in,
                             BL_TO_FORTRAN_ANYD(mask[mfi]), use_mask);

--- a/Source/MaestroReact.cpp
+++ b/Source/MaestroReact.cpp
@@ -142,7 +142,7 @@ void Maestro::Burner(const Vector<MultiFab>& s_in,
             const Box& tileBox = mfi.tilebox();
 
             int use_mask = !(lev==finest_level);
-                
+
             // call fortran subroutine
             // use macros in AMReX_ArrayLim.H to pass in each FAB's data,
             // lo/hi coordinates (including ghost cells), and/or the # of components
@@ -154,17 +154,19 @@ void Maestro::Burner(const Vector<MultiFab>& s_in,
                                  BL_TO_FORTRAN_3D(rho_Hext_mf[mfi]),
                                  BL_TO_FORTRAN_FAB(rho_omegadot_mf[mfi]),
                                  BL_TO_FORTRAN_3D(rho_Hnuc_mf[mfi]),
-                                 BL_TO_FORTRAN_3D(tempbar_cart_mf[mfi]), &dt_in,
-                                 BL_TO_FORTRAN_3D(mask[mfi]), &use_mask);
+                                 BL_TO_FORTRAN_3D(tempbar_cart_mf[mfi]), dt_in,
+                                 BL_TO_FORTRAN_3D(mask[mfi]), use_mask);
             } else {
-                burner_loop(&lev,ARLIM_3D(tileBox.loVect()), ARLIM_3D(tileBox.hiVect()),
-                            BL_TO_FORTRAN_FAB(s_in_mf[mfi]),
-                            BL_TO_FORTRAN_FAB(s_out_mf[mfi]),
-                            BL_TO_FORTRAN_3D(rho_Hext_mf[mfi]),
-                            BL_TO_FORTRAN_FAB(rho_omegadot_mf[mfi]),
-                            BL_TO_FORTRAN_3D(rho_Hnuc_mf[mfi]),
-                            tempbar_init.dataPtr(), &dt_in,
-                            BL_TO_FORTRAN_3D(mask[mfi]), &use_mask);
+#pragma gpu box(tileBox)
+                burner_loop(AMREX_INT_ANYD(tileBox.loVect()), AMREX_INT_ANYD(tileBox.hiVect()),
+                            lev,
+                            BL_TO_FORTRAN_ANYD(s_in_mf[mfi]),
+                            BL_TO_FORTRAN_ANYD(s_out_mf[mfi]),
+                            BL_TO_FORTRAN_ANYD(rho_Hext_mf[mfi]),
+                            BL_TO_FORTRAN_ANYD(rho_omegadot_mf[mfi]),
+                            BL_TO_FORTRAN_ANYD(rho_Hnuc_mf[mfi]),
+                            tempbar_init.dataPtr(), dt_in,
+                            BL_TO_FORTRAN_ANYD(mask[mfi]), use_mask);
             }
         }
     }

--- a/Source/MaestroReact.cpp
+++ b/Source/MaestroReact.cpp
@@ -160,10 +160,10 @@ void Maestro::Burner(const Vector<MultiFab>& s_in,
             if (spherical == 1) {
 #pragma gpu box(tileBox)
                 burner_loop_sphr(AMREX_INT_ANYD(tileBox.loVect()), AMREX_INT_ANYD(tileBox.hiVect()),
-                                 BL_TO_FORTRAN_FAB(s_in_mf[mfi]),
-                                 BL_TO_FORTRAN_FAB(s_out_mf[mfi]),
+                                 BL_TO_FORTRAN_ANYD(s_in_mf[mfi]),
+                                 BL_TO_FORTRAN_ANYD(s_out_mf[mfi]),
                                  BL_TO_FORTRAN_ANYD(rho_Hext_mf[mfi]),
-                                 BL_TO_FORTRAN_FAB(rho_omegadot_mf[mfi]),
+                                 BL_TO_FORTRAN_ANYD(rho_omegadot_mf[mfi]),
                                  BL_TO_FORTRAN_ANYD(rho_Hnuc_mf[mfi]),
                                  BL_TO_FORTRAN_ANYD(tempbar_cart_mf[mfi]), dt_in,
                                  BL_TO_FORTRAN_ANYD(mask[mfi]), use_mask);
@@ -171,10 +171,10 @@ void Maestro::Burner(const Vector<MultiFab>& s_in,
 #pragma gpu box(tileBox)
                 burner_loop(AMREX_INT_ANYD(tileBox.loVect()), AMREX_INT_ANYD(tileBox.hiVect()),
                             lev,
-                            BL_TO_FORTRAN_FAB(s_in_mf[mfi]),
-                            BL_TO_FORTRAN_FAB(s_out_mf[mfi]),
+                            BL_TO_FORTRAN_ANYD(s_in_mf[mfi]),
+                            BL_TO_FORTRAN_ANYD(s_out_mf[mfi]),
                             BL_TO_FORTRAN_ANYD(rho_Hext_mf[mfi]),
-                            BL_TO_FORTRAN_FAB(rho_omegadot_mf[mfi]),
+                            BL_TO_FORTRAN_ANYD(rho_omegadot_mf[mfi]),
                             BL_TO_FORTRAN_ANYD(rho_Hnuc_mf[mfi]),
                             tempbar_init.dataPtr(), dt_in,
                             BL_TO_FORTRAN_ANYD(mask[mfi]), use_mask);

--- a/Source/MaestroReact.cpp
+++ b/Source/MaestroReact.cpp
@@ -45,9 +45,19 @@ Maestro::React (const Vector<MultiFab>& s_in,
     // apply burning term
     if (do_burning) {
 
+#ifdef AMREX_USE_CUDA
+        // turn on GPU
+        Cuda::setLaunchRegion(true);
+#endif
+
         // do the burning, update rho_omegadot and rho_Hnuc
         // we pass in rho_Hext so that we can add it to rhoh in case we applied heating
         Burner(s_in,s_out,rho_Hext,rho_omegadot,rho_Hnuc,p0,dt_in);
+
+#ifdef AMREX_USE_CUDA
+        // turn off GPU
+        Cuda::setLaunchRegion(false);
+#endif
 
         // pass temperature through for seeding the temperature update eos call
         for (int lev=0; lev<=finest_level; ++lev) {

--- a/Source/MaestroThermal.cpp
+++ b/Source/MaestroThermal.cpp
@@ -225,6 +225,11 @@ Maestro::MakeThermalCoeffs(const Vector<MultiFab>& scal,
     // timer for profiling
     BL_PROFILE_VAR("Maestro::MakeThermalCoeffs()",MakeThermalCoeffs);
 
+#ifdef AMREX_USE_CUDA
+    // turn on GPU
+    Cuda::setLaunchRegion(true);
+#endif
+
     for (int lev = 0; lev <= finest_level; ++lev)
     {
         // get references to the MultiFabs at level lev
@@ -243,18 +248,24 @@ Maestro::MakeThermalCoeffs(const Vector<MultiFab>& scal,
         for ( MFIter mfi(scal_mf, true); mfi.isValid(); ++mfi) {
 
             // Get the index space of valid region
-            const Box& tileBox = mfi.tilebox();
+            const Box& gtbx = mfi.growntilebox(1);
 
             // call fortran subroutine
-            make_thermal_coeffs(ARLIM_3D(tileBox.loVect()),ARLIM_3D(tileBox.hiVect()),
+#pragma gpu box(gtbx)
+            make_thermal_coeffs(AMREX_INT_ANYD(gtbx.loVect()),AMREX_INT_ANYD(gtbx.hiVect()),
                                 BL_TO_FORTRAN_FAB(scal_mf[mfi]),
-                                BL_TO_FORTRAN_3D(Tcoeff_mf[mfi]),
-                                BL_TO_FORTRAN_3D(hcoeff_mf[mfi]),
+                                BL_TO_FORTRAN_ANYD(Tcoeff_mf[mfi]),
+                                BL_TO_FORTRAN_ANYD(hcoeff_mf[mfi]),
                                 BL_TO_FORTRAN_FAB(Xkcoeff_mf[mfi]),
-                                BL_TO_FORTRAN_3D(pcoeff_mf[mfi]));
+                                BL_TO_FORTRAN_ANYD(pcoeff_mf[mfi]));
 
         }
     }
+
+#ifdef AMREX_USE_CUDA
+    // turn off GPU
+    Cuda::setLaunchRegion(false);
+#endif
 
 }
 

--- a/Source/MaestroThermal.cpp
+++ b/Source/MaestroThermal.cpp
@@ -253,10 +253,10 @@ Maestro::MakeThermalCoeffs(const Vector<MultiFab>& scal,
             // call fortran subroutine
 #pragma gpu box(gtbx)
             make_thermal_coeffs(AMREX_INT_ANYD(gtbx.loVect()),AMREX_INT_ANYD(gtbx.hiVect()),
-                                BL_TO_FORTRAN_FAB(scal_mf[mfi]),
+                                BL_TO_FORTRAN_ANYD(scal_mf[mfi]),
                                 BL_TO_FORTRAN_ANYD(Tcoeff_mf[mfi]),
                                 BL_TO_FORTRAN_ANYD(hcoeff_mf[mfi]),
-                                BL_TO_FORTRAN_FAB(Xkcoeff_mf[mfi]),
+                                BL_TO_FORTRAN_ANYD(Xkcoeff_mf[mfi]),
                                 BL_TO_FORTRAN_ANYD(pcoeff_mf[mfi]));
 
         }

--- a/Source/Maestro_F.H
+++ b/Source/Maestro_F.H
@@ -17,7 +17,7 @@ extern "C"
 			  const amrex::Real* rho0_old,
 			        amrex::Real* rho0_new,
 			        amrex::Real* rho0_predicted_edge,
-			  const amrex::Real* dt,
+			  const amrex::Real dt,
 			  const amrex::Real* r_cc_loc,
 			  const amrex::Real* r_edge_loc);
 
@@ -27,7 +27,7 @@ extern "C"
 			            amrex::Real* rhoh0_new,
 			      const amrex::Real* rho0_predicted_edge,
 			      const amrex::Real* psi,
-			      const amrex::Real* dt,
+			      const amrex::Real dt,
 			      const amrex::Real* r_cc_loc,
 			      const amrex::Real* r_edge_loc);
     //////////////////////
@@ -108,16 +108,17 @@ extern "C"
 
     //////////////////////
     // in burner_loop.f90
-    void burner_loop(const int* lev, const int* lo, const int* hi,
+    void burner_loop(const int* lo, const int* hi,
+                     const int lev, 
                      const amrex::Real* s_in,     const int* i_lo, const int* i_hi, const int* nc_i,
                            amrex::Real* s_out,    const int* o_lo, const int* o_hi, const int* nc_o,
                      const amrex::Real* rho_Hext, const int* e_lo, const int* e_hi,
                            amrex::Real* rho_odot, const int* r_lo, const int* r_hi, const int* nc_r,
                            amrex::Real* rho_Hnuc, const int* n_lo, const int* n_hi,
                      const amrex::Real* tempbar_init_in,
-                     const amrex::Real* dt_in,
+                     const amrex::Real dt_in,
                      const int* mask, const int* m_lo, const int* m_hi,
-                     const int* use_mask);
+                     const int use_mask);
 
     void burner_loop_sphr(const int* lo, const int* hi,
                           const amrex::Real* s_in,     const int* i_lo, const int* i_hi, const int* nc_i,
@@ -126,9 +127,9 @@ extern "C"
                                 amrex::Real* rho_odot, const int* r_lo, const int* r_hi, const int* nc_r,
                                 amrex::Real* rho_Hnuc, const int* n_lo, const int* n_hi,
                           const amrex::Real* tempbar_init_cart, const int* t_lo, const int* t_hi,
-                          const amrex::Real* dt_in,
+                          const amrex::Real dt_in,
                           const int* mask, const int* m_lo, const int* m_hi,
-                          const int* use_mask);
+                          const int use_mask);
 
     //////////////////////
 
@@ -735,7 +736,7 @@ extern "C"
                             const amrex::Real* p0_cart, const int* p_lo, const int* p_hi,
                             const amrex::Real* gamma1bar_cart, const int* g_lo, const int* g_hi,
                             amrex::Real* deltagamma, const int* d_lo, const int* d_hi);
-                            
+
     void make_entropy(const int* lev, const int* lo, const int* hi,
                      const amrex::Real* state, const int* s_lo, const int* s_hi,
                      const int* nc_s,
@@ -997,7 +998,7 @@ extern "C"
                  const amrex::Real* rho0_old, const amrex::Real* rho0_new,
                  const amrex::Real* p0_old, const amrex::Real* p0_new,
                  const amrex::Real* gamma1bar_old, const amrex::Real* gamma1bar_new,
-                 const amrex::Real* p0_minus_peosbar, 
+                 const amrex::Real* p0_minus_peosbar,
                  const amrex::Real* etarho_ec, const amrex::Real* etarho_cc,
                  const amrex::Real* delta_chi_w0, const amrex::Real* r_cc_loc,
                  const amrex::Real* r_edge_loc, const amrex::Real* dt,

--- a/Source/Maestro_F.H
+++ b/Source/Maestro_F.H
@@ -1150,7 +1150,7 @@ extern "C"
 
     void mk_sponge (const int* lo, const int* hi,
                     amrex::Real* sponge,  const int* s_lo, const int* s_hi,
-                    const amrex::Real* dx, const amrex::Real* dt);
+                    const amrex::Real* dx, const amrex::Real dt);
     //////////////////////
 
 

--- a/Source/Maestro_F.H
+++ b/Source/Maestro_F.H
@@ -110,10 +110,10 @@ extern "C"
     // in burner_loop.f90
     void burner_loop(const int* lo, const int* hi,
                      const int lev,
-                     const amrex::Real* s_in,     const int* i_lo, const int* i_hi, const int* nc_i,
-                           amrex::Real* s_out,    const int* o_lo, const int* o_hi, const int* nc_o,
+                     const amrex::Real* s_in,     const int* i_lo, const int* i_hi,
+                           amrex::Real* s_out,    const int* o_lo, const int* o_hi,
                      const amrex::Real* rho_Hext, const int* e_lo, const int* e_hi,
-                           amrex::Real* rho_odot, const int* r_lo, const int* r_hi, const int* nc_r,
+                           amrex::Real* rho_odot, const int* r_lo, const int* r_hi,
                            amrex::Real* rho_Hnuc, const int* n_lo, const int* n_hi,
                      const amrex::Real* tempbar_init_in,
                      const amrex::Real dt_in,
@@ -121,10 +121,10 @@ extern "C"
                      const int use_mask);
 
     void burner_loop_sphr(const int* lo, const int* hi,
-                          const amrex::Real* s_in,     const int* i_lo, const int* i_hi, const int* nc_i,
-                                amrex::Real* s_out,    const int* o_lo, const int* o_hi, const int* nc_o,
+                          const amrex::Real* s_in,     const int* i_lo, const int* i_hi,
+                                amrex::Real* s_out,    const int* o_lo, const int* o_hi, 
                           const amrex::Real* rho_Hext, const int* e_lo, const int* e_hi,
-                                amrex::Real* rho_odot, const int* r_lo, const int* r_hi, const int* nc_r,
+                                amrex::Real* rho_odot, const int* r_lo, const int* r_hi,
                                 amrex::Real* rho_Hnuc, const int* n_lo, const int* n_hi,
                           const amrex::Real* tempbar_init_cart, const int* t_lo, const int* t_hi,
                           const amrex::Real dt_in,

--- a/Source/Maestro_F.H
+++ b/Source/Maestro_F.H
@@ -109,26 +109,26 @@ extern "C"
     //////////////////////
     // in burner_loop.f90
     void burner_loop(const int* lo, const int* hi,
-                     const int lev, 
-                     const BL_FORT_FAB_ARG_3D(s_in),
-		     BL_FORT_FAB_ARG_3D(s_out),
-                     const BL_FORT_FAB_ARG_3D(rho_Hext),
-		     BL_FORT_FAB_ARG_3D(rho_odot),
-		     BL_FORT_FAB_ARG_3D(rho_Hnuc),
+                     const int lev,
+                     const amrex::Real* s_in,     const int* i_lo, const int* i_hi, const int* nc_i,
+                           amrex::Real* s_out,    const int* o_lo, const int* o_hi, const int* nc_o,
+                     const amrex::Real* rho_Hext, const int* e_lo, const int* e_hi,
+                           amrex::Real* rho_odot, const int* r_lo, const int* r_hi, const int* nc_r,
+                           amrex::Real* rho_Hnuc, const int* n_lo, const int* n_hi,
                      const amrex::Real* tempbar_init_in,
                      const amrex::Real dt_in,
-                     const BL_FORT_IFAB_ARG_3D(mask),
+                     const int* mask, const int* m_lo, const int* m_hi,
                      const int use_mask);
 
     void burner_loop_sphr(const int* lo, const int* hi,
-                          const BL_FORT_FAB_ARG_3D(s_in),
-			  BL_FORT_FAB_ARG_3D(s_out),
-                          const BL_FORT_FAB_ARG_3D(rho_Hext),
-			  BL_FORT_FAB_ARG_3D(rho_odot),
-			  BL_FORT_FAB_ARG_3D(rho_Hnuc),
-                          const BL_FORT_FAB_ARG_3D(tempbar_init_cart),
+                          const amrex::Real* s_in,     const int* i_lo, const int* i_hi, const int* nc_i,
+                                amrex::Real* s_out,    const int* o_lo, const int* o_hi, const int* nc_o,
+                          const amrex::Real* rho_Hext, const int* e_lo, const int* e_hi,
+                                amrex::Real* rho_odot, const int* r_lo, const int* r_hi, const int* nc_r,
+                                amrex::Real* rho_Hnuc, const int* n_lo, const int* n_hi,
+                          const amrex::Real* tempbar_init_cart, const int* t_lo, const int* t_hi,
                           const amrex::Real dt_in,
-                          const BL_FORT_IFAB_ARG_3D(mask),
+                          const int* mask, const int* m_lo, const int* m_hi,
                           const int use_mask);
 
     //////////////////////

--- a/Source/Maestro_F.H
+++ b/Source/Maestro_F.H
@@ -110,25 +110,25 @@ extern "C"
     // in burner_loop.f90
     void burner_loop(const int* lo, const int* hi,
                      const int lev, 
-                     const amrex::Real* s_in,     const int* i_lo, const int* i_hi, const int* nc_i,
-                           amrex::Real* s_out,    const int* o_lo, const int* o_hi, const int* nc_o,
-                     const amrex::Real* rho_Hext, const int* e_lo, const int* e_hi,
-                           amrex::Real* rho_odot, const int* r_lo, const int* r_hi, const int* nc_r,
-                           amrex::Real* rho_Hnuc, const int* n_lo, const int* n_hi,
+                     const BL_FORT_FAB_ARG_3D(s_in),
+		     BL_FORT_FAB_ARG_3D(s_out),
+                     const BL_FORT_FAB_ARG_3D(rho_Hext),
+		     BL_FORT_FAB_ARG_3D(rho_odot),
+		     BL_FORT_FAB_ARG_3D(rho_Hnuc),
                      const amrex::Real* tempbar_init_in,
                      const amrex::Real dt_in,
-                     const int* mask, const int* m_lo, const int* m_hi,
+                     const BL_FORT_IFAB_ARG_3D(mask),
                      const int use_mask);
 
     void burner_loop_sphr(const int* lo, const int* hi,
-                          const amrex::Real* s_in,     const int* i_lo, const int* i_hi, const int* nc_i,
-                                amrex::Real* s_out,    const int* o_lo, const int* o_hi, const int* nc_o,
-                          const amrex::Real* rho_Hext, const int* e_lo, const int* e_hi,
-                                amrex::Real* rho_odot, const int* r_lo, const int* r_hi, const int* nc_r,
-                                amrex::Real* rho_Hnuc, const int* n_lo, const int* n_hi,
-                          const amrex::Real* tempbar_init_cart, const int* t_lo, const int* t_hi,
+                          const BL_FORT_FAB_ARG_3D(s_in),
+			  BL_FORT_FAB_ARG_3D(s_out),
+                          const BL_FORT_FAB_ARG_3D(rho_Hext),
+			  BL_FORT_FAB_ARG_3D(rho_odot),
+			  BL_FORT_FAB_ARG_3D(rho_Hnuc),
+                          const BL_FORT_FAB_ARG_3D(tempbar_init_cart),
                           const amrex::Real dt_in,
-                          const int* mask, const int* m_lo, const int* m_hi,
+                          const BL_FORT_IFAB_ARG_3D(mask),
                           const int use_mask);
 
     //////////////////////

--- a/Source/Maestro_F.H
+++ b/Source/Maestro_F.H
@@ -503,7 +503,7 @@ extern "C"
 
     //////////////////////
     // in make_explicit_thermal.F90
-    void make_thermal_coeffs(const int* lo,  const int *hi,
+    void make_thermal_coeffs(const int* lo,  const int* hi,
 			     const amrex::Real* scal, const int* s_lo, const int* s_hi, const int* nc_s,
 			     amrex::Real* Tcoeff, const int* t_lo, const int* t_hi,
 			     amrex::Real* hcoeff, const int* h_lo, const int* h_hi,

--- a/Source/Maestro_F.H
+++ b/Source/Maestro_F.H
@@ -122,7 +122,7 @@ extern "C"
 
     void burner_loop_sphr(const int* lo, const int* hi,
                           const amrex::Real* s_in,     const int* i_lo, const int* i_hi,
-                                amrex::Real* s_out,    const int* o_lo, const int* o_hi, 
+                                amrex::Real* s_out,    const int* o_lo, const int* o_hi,
                           const amrex::Real* rho_Hext, const int* e_lo, const int* e_hi,
                                 amrex::Real* rho_odot, const int* r_lo, const int* r_hi,
                                 amrex::Real* rho_Hnuc, const int* n_lo, const int* n_hi,
@@ -504,10 +504,10 @@ extern "C"
     //////////////////////
     // in make_explicit_thermal.F90
     void make_thermal_coeffs(const int* lo,  const int* hi,
-			     const amrex::Real* scal, const int* s_lo, const int* s_hi, const int* nc_s,
+			     const amrex::Real* scal, const int* s_lo, const int* s_hi,
 			     amrex::Real* Tcoeff, const int* t_lo, const int* t_hi,
 			     amrex::Real* hcoeff, const int* h_lo, const int* h_hi,
-			     amrex::Real* Xkcoeff, const int* xk_lo, const int* xk_hi, const int* nc_xk,
+			     amrex::Real* Xkcoeff, const int* xk_lo, const int* xk_hi,
 			     amrex::Real* pcoeff, const int* p_lo, const int* p_hi);
     //////////////////////
 

--- a/Source/Src_nd/Make.package
+++ b/Source/Src_nd/Make.package
@@ -1,8 +1,8 @@
 f90EXE_sources += average.f90
 f90EXE_sources += base_state.f90
-f90EXE_sources += base_state_geometry.f90
+F90EXE_sources += base_state_geometry.F90
 #ifdef REACTIONS
-f90EXE_sources += burner_loop.f90
+F90EXE_sources += burner_loop.F90
 #endif
 f90EXE_sources += cell_to_edge.f90
 f90EXE_sources += enforce_HSE.f90

--- a/Source/Src_nd/advect_base.F90
+++ b/Source/Src_nd/advect_base.F90
@@ -24,12 +24,12 @@ contains
     double precision, intent(in   ) ::            rho0_old(0:max_radial_level,0:nr_fine-1)
     double precision, intent(  out) ::            rho0_new(0:max_radial_level,0:nr_fine-1)
     double precision, intent(  out) :: rho0_predicted_edge(0:max_radial_level,0:nr_fine  )
-    double precision, intent(in   ) ::                  dt
+    double precision, value, intent(in   ) ::                  dt
     double precision, intent(in   ) ::            r_cc_loc(0:max_radial_level,0:nr_fine-1)
     double precision, intent(in   ) ::          r_edge_loc(0:max_radial_level,0:nr_fine  )
 
     call bl_proffortfuncstart("Maestro::advect_base_dens")
-    
+
     if (spherical .eq. 0) then
        call advect_base_dens_planar(w0,rho0_old,rho0_new,rho0_predicted_edge,dt)
        call restrict_base(rho0_new,1)
@@ -38,7 +38,7 @@ contains
        call advect_base_dens_spherical(w0,rho0_old,rho0_new,rho0_predicted_edge,dt, &
             r_cc_loc,r_edge_loc)
     end if
-    
+
     call bl_proffortfuncstop("Maestro::advect_base_dens")
 
   end subroutine advect_base_dens
@@ -52,7 +52,7 @@ contains
     double precision, intent(in   ) ::            rho0_old(0:max_radial_level,0:nr_fine-1)
     double precision, intent(  out) ::            rho0_new(0:max_radial_level,0:nr_fine-1)
     double precision, intent(  out) :: rho0_predicted_edge(0:max_radial_level,0:nr_fine  )
-    double precision, intent(in   ) ::                  dt
+    double precision, value, intent(in   ) ::                  dt
 
     ! Local variables
     integer :: r, n, i
@@ -102,7 +102,7 @@ contains
     double precision, intent(in   ) ::            rho0_old(0:max_radial_level,0:nr_fine-1)
     double precision, intent(  out) ::            rho0_new(0:max_radial_level,0:nr_fine-1)
     double precision, intent(  out) :: rho0_predicted_edge(0:max_radial_level,0:nr_fine  )
-    double precision, intent(in   ) ::                  dt
+    double precision, value, intent(in   ) ::                  dt
     double precision, intent(in   ) ::            r_cc_loc(0:max_radial_level,0:nr_fine-1)
     double precision, intent(in   ) ::          r_edge_loc(0:max_radial_level,0:nr_fine  )
 
@@ -150,12 +150,12 @@ contains
     double precision, intent(  out) ::           rhoh0_new(0:max_radial_level,0:nr_fine-1)
     double precision, intent(in   ) :: rho0_predicted_edge(0:max_radial_level,0:nr_fine  )
     double precision, intent(in   ) ::                 psi(0:max_radial_level,0:nr_fine-1)
-    double precision, intent(in   ) ::                  dt
+    double precision, value, intent(in   ) ::                  dt
     double precision, intent(in   ) ::            r_cc_loc(0:max_radial_level,0:nr_fine-1)
     double precision, intent(in   ) ::          r_edge_loc(0:max_radial_level,0:nr_fine  )
 
     call bl_proffortfuncstart("Maestro::advect_base_enthalpy")
-    
+
     if (spherical .eq. 0) then
        call advect_base_enthalpy_planar(w0,rho0_old,rhoh0_old,rhoh0_new, &
             rho0_predicted_edge,psi,dt)
@@ -166,7 +166,7 @@ contains
             rho0_predicted_edge,psi,dt, &
             r_cc_loc, r_edge_loc)
     end if
-    
+
     call bl_proffortfuncstop("Maestro::advect_base_enthalpy")
 
   end subroutine advect_base_enthalpy
@@ -182,7 +182,7 @@ contains
     double precision, intent(  out) ::           rhoh0_new(0:max_radial_level,0:nr_fine-1)
     double precision, intent(in   ) :: rho0_predicted_edge(0:max_radial_level,0:nr_fine  )
     double precision, intent(in   ) ::                 psi(0:max_radial_level,0:nr_fine-1)
-    double precision, intent(in   ) ::                  dt
+    double precision, value, intent(in   ) ::                  dt
 
     ! Local variables
     integer :: r, i, n
@@ -232,7 +232,7 @@ contains
     double precision, intent(  out) ::           rhoh0_new(0:max_radial_level,0:nr_fine-1)
     double precision, intent(in   ) :: rho0_predicted_edge(0:max_radial_level,0:nr_fine  )
     double precision, intent(in   ) ::                 psi(0:max_radial_level,0:nr_fine-1)
-    double precision, intent(in   ) ::                  dt
+    double precision, value, intent(in   ) ::                  dt
     double precision, intent(in   ) ::            r_cc_loc(0:max_radial_level,0:nr_fine-1)
     double precision, intent(in   ) ::          r_edge_loc(0:max_radial_level,0:nr_fine  )
 

--- a/Source/Src_nd/base_state_geometry.F90
+++ b/Source/Src_nd/base_state_geometry.F90
@@ -27,13 +27,13 @@ module base_state_geometry_module
   ! finest_radial_level is the current finest level index, which may be less than
   ! max_radial_level depending on the refinement criteria
 
-  integer         , save, public :: max_radial_level
-  integer         , save, public :: finest_radial_level
-  integer         , save, public :: nr_fine   ! number of zones associated with *max_radial_level*
-  double precision, save, public :: dr_fine   ! base state grid spacing associated with *max_radial_level*
+  integer         , allocatable, save, public :: max_radial_level
+  integer         , allocatable, save, public :: finest_radial_level
+  integer         , allocatable, save, public :: nr_fine   ! number of zones associated with *max_radial_level*
+  double precision, allocatable, save, public :: dr_fine   ! base state grid spacing associated with *max_radial_level*
 
-  integer         , save, public  :: nr_irreg
-  double precision, save, public  :: center(3)
+  integer         , allocatable, save, public  :: nr_irreg
+  double precision, allocatable, save, public  :: center(:)
 
   double precision, pointer, save, public  :: dr(:)
   integer         , pointer, save, public  :: nr(:)
@@ -45,6 +45,10 @@ module base_state_geometry_module
   integer         , pointer, save, public  :: anelastic_cutoff_density_coord(:)
   integer         , pointer, save, public  :: base_cutoff_density_coord(:)
   integer         , pointer, save, public  :: burning_cutoff_density_coord(:)
+
+#ifdef AMREX_USE_CUDA
+  attributes(managed) :: max_radial_level, finest_radial_level, nr_fine, dr_fine, nr_irreg, center
+#endif
 
 contains
 
@@ -68,6 +72,13 @@ contains
     if ( parallel_IOProcessor() ) then
        print*,'Calling init_base_state_geometry()'
     end if
+
+    allocate(max_radial_level)
+    allocate(finest_radial_level)
+    allocate(nr_fine)
+    allocate(dr_fine)
+    allocate(nr_irreg)
+    allocate(center(3))
 
     max_radial_level = max_radial_level_in
     nr_fine = nr_fine_in

--- a/Source/Src_nd/burner_loop.F90
+++ b/Source/Src_nd/burner_loop.F90
@@ -22,7 +22,6 @@ module burner_loop_module
   attributes(managed) :: ispec_threshold
 #endif
 
-
 contains
 
   subroutine burner_loop_init()

--- a/Source/Src_nd/burner_loop.F90
+++ b/Source/Src_nd/burner_loop.F90
@@ -87,103 +87,103 @@ contains
        firstCall = .false.
     endif
 
-!     do k = lo(3), hi(3)
-!        do j = lo(2), hi(2)
-!           do i = lo(1), hi(1)
-!
-!              ! make sure the cell isn't covered by finer cells
-!              cell_valid = .true.
-!              if ( use_mask .eq. 1 ) then
-!                 if ( (mask(i,j,k).eq.1) ) cell_valid = .false.
-!              endif
-!
-!              if (cell_valid) then
-!                 rho = s_in(i,j,k,rho_comp)
-!                 do n = 1, nspec
-!                    x_in(n) = s_in(i,j,k,n+spec_comp-1) / rho
-!                 enddo
-!
-!                 if (drive_initial_convection) then
-!                    T_in = tempbar_init_in(lev,k)
-!                 else
-!                    T_in = s_in(i,j,k,temp_comp)
-!                 endif
-!
-!                 ! Fortran doesn't guarantee short-circuit evaluation of logicals
-!                 ! so we need to test the value of ispec_threshold before using it
-!                 ! as an index in x_in
-!                 if (ispec_threshold > 0) then
-!                    x_test = x_in(ispec_threshold)
-!                 else
-!                    x_test = 0.d0
-!                 endif
-!
-!                 ! if the threshold species is not in the network, then we burn
-!                 ! normally.  if it is in the network, make sure the mass
-!                 ! fraction is above the cutoff.
-!                 if (rho > burning_cutoff_density .and.                &
-!                      ( ispec_threshold < 0 .or.                       &
-!                      (ispec_threshold > 0 .and. x_test > burner_threshold_cutoff) ) ) then
-!                    ! Initialize burn state_in and state_out
-!                    state_in % e   = 0.0d0
-!                    state_in % rho = rho
-!                    state_in % T   = T_in
-!                    do n = 1, nspec
-!                       state_in % xn(n) = x_in(n)
-!                    enddo
-!                    state_out = state_in
-!                    call burner(state_in, state_out, dt_in)
-!                    do n = 1, nspec
-!                       x_out(n) = state_out % xn(n)
-!                    enddo
-!                    do n = 1, nspec
-!                       rhowdot(n) = state_out % rho * &
-!                            (state_out % xn(n) - state_in % xn(n)) / dt_in
-!                    enddo
-!                    rhoH = state_out % rho * (state_out % e - state_in % e) / dt_in
-!                 else
-!                    x_out = x_in
-!                    rhowdot = 0.d0
-!                    rhoH = 0.d0
-!                 endif
-!
-!                 ! check if sum{X_k} = 1
-!                 sumX = 0.d0
-!                 do n = 1, nspec
-!                    sumX = sumX + x_out(n)
-!                 enddo
-!                 if (abs(sumX - 1.d0) > reaction_sum_tol) then
-! #ifndef AMREX_USE_GPU
-!                    call amrex_error("ERROR: abundances do not sum to 1", abs(sumX-1.d0))
-! #endif
-!                    do n = 1, nspec
-!                       state_out % xn(n) = state_out % xn(n)/sumX
-!                    enddo
-!                 endif
-!
-!                 ! pass the density and pi through
-!                 s_out(i,j,k,rho_comp) = s_in(i,j,k,rho_comp)
-!                 s_out(i,j,k,pi_comp) = s_in(i,j,k,pi_comp)
-!
-!                 ! update the species
-!                 do n = 1, nspec
-!                    s_out(i,j,k,n+spec_comp-1) = x_out(n) * rho
-!                 enddo
-!
-!                 ! store the energy generation and species create quantities
-!                 do n = 1, nspec
-!                    rho_odot(i,j,k,n) = rhowdot(n)
-!                 enddo
-!                 rho_Hnuc(i,j,k) = rhoH
-!
-!                 ! update the enthalpy -- include the change due to external heating
-!                 s_out(i,j,k,rhoh_comp) = s_in(i,j,k,rhoh_comp) &
-!                      + dt_in*rho_Hnuc(i,j,k) + dt_in*rho_Hext(i,j,k)
-!
-!              endif
-!           enddo
-!        enddo
-!     enddo
+    do k = lo(3), hi(3)
+       do j = lo(2), hi(2)
+          do i = lo(1), hi(1)
+
+             ! make sure the cell isn't covered by finer cells
+             cell_valid = .true.
+             if ( use_mask .eq. 1 ) then
+                if ( (mask(i,j,k).eq.1) ) cell_valid = .false.
+             endif
+
+             if (cell_valid) then
+                rho = s_in(i,j,k,rho_comp)
+                do n = 1, nspec
+                   x_in(n) = s_in(i,j,k,n+spec_comp-1) / rho
+                enddo
+
+                if (drive_initial_convection) then
+                   T_in = tempbar_init_in(lev,k)
+                else
+                   T_in = s_in(i,j,k,temp_comp)
+                endif
+
+                ! Fortran doesn't guarantee short-circuit evaluation of logicals
+                ! so we need to test the value of ispec_threshold before using it
+                ! as an index in x_in
+                if (ispec_threshold > 0) then
+                   x_test = x_in(ispec_threshold)
+                else
+                   x_test = 0.d0
+                endif
+
+                ! if the threshold species is not in the network, then we burn
+                ! normally.  if it is in the network, make sure the mass
+                ! fraction is above the cutoff.
+                if (rho > burning_cutoff_density .and.                &
+                     ( ispec_threshold < 0 .or.                       &
+                     (ispec_threshold > 0 .and. x_test > burner_threshold_cutoff) ) ) then
+                   ! Initialize burn state_in and state_out
+                   state_in % e   = 0.0d0
+                   state_in % rho = rho
+                   state_in % T   = T_in
+                   do n = 1, nspec
+                      state_in % xn(n) = x_in(n)
+                   enddo
+                   state_out = state_in
+                   call burner(state_in, state_out, dt_in)
+                   do n = 1, nspec
+                      x_out(n) = state_out % xn(n)
+                   enddo
+                   do n = 1, nspec
+                      rhowdot(n) = state_out % rho * &
+                           (state_out % xn(n) - state_in % xn(n)) / dt_in
+                   enddo
+                   rhoH = state_out % rho * (state_out % e - state_in % e) / dt_in
+                else
+                   x_out = x_in
+                   rhowdot = 0.d0
+                   rhoH = 0.d0
+                endif
+
+                ! check if sum{X_k} = 1
+                sumX = 0.d0
+                do n = 1, nspec
+                   sumX = sumX + x_out(n)
+                enddo
+                if (abs(sumX - 1.d0) > reaction_sum_tol) then
+#ifndef AMREX_USE_GPU
+                   call amrex_error("ERROR: abundances do not sum to 1", abs(sumX-1.d0))
+#endif
+                   do n = 1, nspec
+                      state_out % xn(n) = state_out % xn(n)/sumX
+                   enddo
+                endif
+
+                ! pass the density and pi through
+                s_out(i,j,k,rho_comp) = s_in(i,j,k,rho_comp)
+                s_out(i,j,k,pi_comp) = s_in(i,j,k,pi_comp)
+
+                ! update the species
+                do n = 1, nspec
+                   s_out(i,j,k,n+spec_comp-1) = x_out(n) * rho
+                enddo
+
+                ! store the energy generation and species create quantities
+                do n = 1, nspec
+                   rho_odot(i,j,k,n) = rhowdot(n)
+                enddo
+                rho_Hnuc(i,j,k) = rhoH
+
+                ! update the enthalpy -- include the change due to external heating
+                s_out(i,j,k,rhoh_comp) = s_in(i,j,k,rhoh_comp) &
+                     + dt_in*rho_Hnuc(i,j,k) + dt_in*rho_Hext(i,j,k)
+
+             endif
+          enddo
+       enddo
+    enddo
 
   end subroutine burner_loop
 

--- a/Source/Src_nd/burner_loop.F90
+++ b/Source/Src_nd/burner_loop.F90
@@ -14,11 +14,28 @@ module burner_loop_module
 
   private
 
-  integer, save :: ispec_threshold
-  logical, save :: firstCall = .true.
+  integer, allocatable, save :: ispec_threshold, burner_threshold_species_index
+  logical, allocatable, save :: firstCall != .true.
+
+#ifdef AMREX_USE_CUDA
+  attributes(managed) :: ispec_threshold
+  attributes(managed) :: burner_threshold_species_index
+  attributes(managed) :: firstCall
+#endif
 
 
 contains
+
+  subroutine burner_loop_init()
+
+      allocate(ispec_threshold)
+      allocate(burner_threshold_species_index)
+      allocate(firstCall)
+
+      burner_threshold_species_index = network_species_index(burner_threshold_species)
+      firstCall = .true.
+
+  end subroutine burner_loop_init
 
   subroutine burner_loop(lo, hi, &
        lev, &
@@ -66,105 +83,107 @@ contains
     !$gpu
 
     if (firstCall) then
-       ispec_threshold = network_species_index(burner_threshold_species)
+       ! ispec_threshold = network_species_index(burner_threshold_species)
        firstCall = .false.
     endif
 
-    do k = lo(3), hi(3)
-       do j = lo(2), hi(2)
-          do i = lo(1), hi(1)
-
-             ! make sure the cell isn't covered by finer cells
-             cell_valid = .true.
-             if ( use_mask .eq. 1 ) then
-                if ( (mask(i,j,k).eq.1) ) cell_valid = .false.
-             endif
-
-             if (cell_valid) then
-                rho = s_in(i,j,k,rho_comp)
-                do n = 1, nspec
-                   x_in(n) = s_in(i,j,k,n+spec_comp-1) / rho
-                enddo
-
-                if (drive_initial_convection) then
-                   T_in = tempbar_init_in(lev,k)
-                else
-                   T_in = s_in(i,j,k,temp_comp)
-                endif
-
-                ! Fortran doesn't guarantee short-circuit evaluation of logicals
-                ! so we need to test the value of ispec_threshold before using it
-                ! as an index in x_in
-                if (ispec_threshold > 0) then
-                   x_test = x_in(ispec_threshold)
-                else
-                   x_test = 0.d0
-                endif
-
-                ! if the threshold species is not in the network, then we burn
-                ! normally.  if it is in the network, make sure the mass
-                ! fraction is above the cutoff.
-                if (rho > burning_cutoff_density .and.                &
-                     ( ispec_threshold < 0 .or.                       &
-                     (ispec_threshold > 0 .and. x_test > burner_threshold_cutoff) ) ) then
-                   ! Initialize burn state_in and state_out
-                   state_in % e   = 0.0d0
-                   state_in % rho = rho
-                   state_in % T   = T_in
-                   do n = 1, nspec
-                      state_in % xn(n) = x_in(n)
-                   enddo
-                   state_out = state_in
-                   call burner(state_in, state_out, dt_in)
-                   do n = 1, nspec
-                      x_out(n) = state_out % xn(n)
-                   enddo
-                   do n = 1, nspec
-                      rhowdot(n) = state_out % rho * &
-                           (state_out % xn(n) - state_in % xn(n)) / dt_in
-                   enddo
-                   rhoH = state_out % rho * (state_out % e - state_in % e) / dt_in
-                else
-                   x_out = x_in
-                   rhowdot = 0.d0
-                   rhoH = 0.d0
-                endif
-
-                ! check if sum{X_k} = 1
-                sumX = 0.d0
-                do n = 1, nspec
-                   sumX = sumX + x_out(n)
-                enddo
-                if (abs(sumX - 1.d0) > reaction_sum_tol) then
-                   call amrex_error("ERROR: abundances do not sum to 1", abs(sumX-1.d0))
-                   do n = 1, nspec
-                      state_out % xn(n) = state_out % xn(n)/sumX
-                   enddo
-                endif
-
-                ! pass the density and pi through
-                s_out(i,j,k,rho_comp) = s_in(i,j,k,rho_comp)
-                s_out(i,j,k,pi_comp) = s_in(i,j,k,pi_comp)
-
-                ! update the species
-                do n = 1, nspec
-                   s_out(i,j,k,n+spec_comp-1) = x_out(n) * rho
-                enddo
-
-                ! store the energy generation and species create quantities
-                do n = 1, nspec
-                   rho_odot(i,j,k,n) = rhowdot(n)
-                enddo
-                rho_Hnuc(i,j,k) = rhoH
-
-                ! update the enthalpy -- include the change due to external heating
-                s_out(i,j,k,rhoh_comp) = s_in(i,j,k,rhoh_comp) &
-                     + dt_in*rho_Hnuc(i,j,k) + dt_in*rho_Hext(i,j,k)
-
-             endif
-          enddo
-       enddo
-    enddo
+!     do k = lo(3), hi(3)
+!        do j = lo(2), hi(2)
+!           do i = lo(1), hi(1)
+!
+!              ! make sure the cell isn't covered by finer cells
+!              cell_valid = .true.
+!              if ( use_mask .eq. 1 ) then
+!                 if ( (mask(i,j,k).eq.1) ) cell_valid = .false.
+!              endif
+!
+!              if (cell_valid) then
+!                 rho = s_in(i,j,k,rho_comp)
+!                 do n = 1, nspec
+!                    x_in(n) = s_in(i,j,k,n+spec_comp-1) / rho
+!                 enddo
+!
+!                 if (drive_initial_convection) then
+!                    T_in = tempbar_init_in(lev,k)
+!                 else
+!                    T_in = s_in(i,j,k,temp_comp)
+!                 endif
+!
+!                 ! Fortran doesn't guarantee short-circuit evaluation of logicals
+!                 ! so we need to test the value of ispec_threshold before using it
+!                 ! as an index in x_in
+!                 if (ispec_threshold > 0) then
+!                    x_test = x_in(ispec_threshold)
+!                 else
+!                    x_test = 0.d0
+!                 endif
+!
+!                 ! if the threshold species is not in the network, then we burn
+!                 ! normally.  if it is in the network, make sure the mass
+!                 ! fraction is above the cutoff.
+!                 if (rho > burning_cutoff_density .and.                &
+!                      ( ispec_threshold < 0 .or.                       &
+!                      (ispec_threshold > 0 .and. x_test > burner_threshold_cutoff) ) ) then
+!                    ! Initialize burn state_in and state_out
+!                    state_in % e   = 0.0d0
+!                    state_in % rho = rho
+!                    state_in % T   = T_in
+!                    do n = 1, nspec
+!                       state_in % xn(n) = x_in(n)
+!                    enddo
+!                    state_out = state_in
+!                    call burner(state_in, state_out, dt_in)
+!                    do n = 1, nspec
+!                       x_out(n) = state_out % xn(n)
+!                    enddo
+!                    do n = 1, nspec
+!                       rhowdot(n) = state_out % rho * &
+!                            (state_out % xn(n) - state_in % xn(n)) / dt_in
+!                    enddo
+!                    rhoH = state_out % rho * (state_out % e - state_in % e) / dt_in
+!                 else
+!                    x_out = x_in
+!                    rhowdot = 0.d0
+!                    rhoH = 0.d0
+!                 endif
+!
+!                 ! check if sum{X_k} = 1
+!                 sumX = 0.d0
+!                 do n = 1, nspec
+!                    sumX = sumX + x_out(n)
+!                 enddo
+!                 if (abs(sumX - 1.d0) > reaction_sum_tol) then
+! #ifndef AMREX_USE_GPU
+!                    call amrex_error("ERROR: abundances do not sum to 1", abs(sumX-1.d0))
+! #endif
+!                    do n = 1, nspec
+!                       state_out % xn(n) = state_out % xn(n)/sumX
+!                    enddo
+!                 endif
+!
+!                 ! pass the density and pi through
+!                 s_out(i,j,k,rho_comp) = s_in(i,j,k,rho_comp)
+!                 s_out(i,j,k,pi_comp) = s_in(i,j,k,pi_comp)
+!
+!                 ! update the species
+!                 do n = 1, nspec
+!                    s_out(i,j,k,n+spec_comp-1) = x_out(n) * rho
+!                 enddo
+!
+!                 ! store the energy generation and species create quantities
+!                 do n = 1, nspec
+!                    rho_odot(i,j,k,n) = rhowdot(n)
+!                 enddo
+!                 rho_Hnuc(i,j,k) = rhoH
+!
+!                 ! update the enthalpy -- include the change due to external heating
+!                 s_out(i,j,k,rhoh_comp) = s_in(i,j,k,rhoh_comp) &
+!                      + dt_in*rho_Hnuc(i,j,k) + dt_in*rho_Hext(i,j,k)
+!
+!              endif
+!           enddo
+!        enddo
+!     enddo
 
   end subroutine burner_loop
 
@@ -213,7 +232,7 @@ contains
     !$gpu
 
     if (firstCall) then
-       ispec_threshold = network_species_index(burner_threshold_species)
+       ! ispec_threshold = network_species_index(burner_threshold_species)
        firstCall = .false.
     endif
 

--- a/Source/Src_nd/burner_loop.F90
+++ b/Source/Src_nd/burner_loop.F90
@@ -5,7 +5,7 @@ module burner_loop_module
   use burn_type_module, only: burn_t, copy_burn_t
   use network, only: nspec, network_species_index
   use meth_params_module, only: rho_comp, rhoh_comp, temp_comp, spec_comp, &
-       pi_comp, burner_threshold_cutoff, burner_threshold_species, &
+       pi_comp, nscal, burner_threshold_cutoff, burner_threshold_species, &
        burning_cutoff_density, reaction_sum_tol, &
        drive_initial_convection
   use base_state_geometry_module, only: max_radial_level, nr_fine
@@ -34,10 +34,10 @@ contains
 
   subroutine burner_loop(lo, hi, &
        lev, &
-       s_in,     i_lo, i_hi, nc_i, &
-       s_out,    o_lo, o_hi, nc_o, &
+       s_in,     i_lo, i_hi, &
+       s_out,    o_lo, o_hi, &
        rho_Hext, e_lo, e_hi, &
-       rho_odot, r_lo, r_hi, nc_r, &
+       rho_odot, r_lo, r_hi, &
        rho_Hnuc, n_lo, n_hi, &
        tempbar_init_in, dt_in, &
        mask,     m_lo, m_hi, use_mask) &
@@ -45,16 +45,16 @@ contains
 
     integer         , intent (in   ) :: lo(3), hi(3)
     integer, value  , intent (in   ) :: lev
-    integer         , intent (in   ) :: i_lo(3), i_hi(3), nc_i
-    integer         , intent (in   ) :: o_lo(3), o_hi(3), nc_o
+    integer         , intent (in   ) :: i_lo(3), i_hi(3)
+    integer         , intent (in   ) :: o_lo(3), o_hi(3)
     integer         , intent (in   ) :: e_lo(3), e_hi(3)
-    integer         , intent (in   ) :: r_lo(3), r_hi(3), nc_r
+    integer         , intent (in   ) :: r_lo(3), r_hi(3)
     integer         , intent (in   ) :: n_lo(3), n_hi(3)
     integer         , intent (in   ) :: m_lo(3), m_hi(3)
-    double precision, intent (in   ) ::    s_in (i_lo(1):i_hi(1),i_lo(2):i_hi(2),i_lo(3):i_hi(3),nc_i)
-    double precision, intent (inout) ::    s_out(o_lo(1):o_hi(1),o_lo(2):o_hi(2),o_lo(3):o_hi(3),nc_o)
+    double precision, intent (in   ) ::    s_in (i_lo(1):i_hi(1),i_lo(2):i_hi(2),i_lo(3):i_hi(3),nscal)
+    double precision, intent (inout) ::    s_out(o_lo(1):o_hi(1),o_lo(2):o_hi(2),o_lo(3):o_hi(3),nscal)
     double precision, intent (in   ) :: rho_Hext(e_lo(1):e_hi(1),e_lo(2):e_hi(2),e_lo(3):e_hi(3))
-    double precision, intent (inout) :: rho_odot(r_lo(1):r_hi(1),r_lo(2):r_hi(2),r_lo(3):r_hi(3),nc_r)
+    double precision, intent (inout) :: rho_odot(r_lo(1):r_hi(1),r_lo(2):r_hi(2),r_lo(3):r_hi(3),nspec)
     double precision, intent (inout) :: rho_Hnuc(n_lo(1):n_hi(1),n_lo(2):n_hi(2),n_lo(3):n_hi(3))
     double precision, intent (in   ) :: tempbar_init_in(0:max_radial_level,0:nr_fine-1)
     double precision, value, intent (in) :: dt_in
@@ -178,26 +178,26 @@ contains
   end subroutine burner_loop
 
   subroutine burner_loop_sphr(lo, hi, &
-       s_in,     i_lo, i_hi, nc_i, &
-       s_out,    o_lo, o_hi, nc_o, &
+       s_in,     i_lo, i_hi, &
+       s_out,    o_lo, o_hi, &
        rho_Hext, e_lo, e_hi, &
-       rho_odot, r_lo, r_hi, nc_r, &
+       rho_odot, r_lo, r_hi, &
        rho_Hnuc, n_lo, n_hi, &
        tempbar_init_cart, t_lo, t_hi, dt_in, &
        mask,     m_lo, m_hi, use_mask) &
        bind (C,name="burner_loop_sphr")
 
     integer         , intent (in   ) :: lo(3), hi(3)
-    integer         , intent (in   ) :: i_lo(3), i_hi(3), nc_i
-    integer         , intent (in   ) :: o_lo(3), o_hi(3), nc_o
+    integer         , intent (in   ) :: i_lo(3), i_hi(3)
+    integer         , intent (in   ) :: o_lo(3), o_hi(3)
     integer         , intent (in   ) :: e_lo(3), e_hi(3)
-    integer         , intent (in   ) :: r_lo(3), r_hi(3), nc_r
+    integer         , intent (in   ) :: r_lo(3), r_hi(3)
     integer         , intent (in   ) :: n_lo(3), n_hi(3)
     integer         , intent (in   ) :: m_lo(3), m_hi(3)
-    double precision, intent (in   ) ::    s_in (i_lo(1):i_hi(1),i_lo(2):i_hi(2),i_lo(3):i_hi(3),nc_i)
-    double precision, intent (inout) ::    s_out(o_lo(1):o_hi(1),o_lo(2):o_hi(2),o_lo(3):o_hi(3),nc_o)
+    double precision, intent (in   ) ::    s_in (i_lo(1):i_hi(1),i_lo(2):i_hi(2),i_lo(3):i_hi(3),nscal)
+    double precision, intent (inout) ::    s_out(o_lo(1):o_hi(1),o_lo(2):o_hi(2),o_lo(3):o_hi(3),nscal)
     double precision, intent (in   ) :: rho_Hext(e_lo(1):e_hi(1),e_lo(2):e_hi(2),e_lo(3):e_hi(3))
-    double precision, intent (inout) :: rho_odot(r_lo(1):r_hi(1),r_lo(2):r_hi(2),r_lo(3):r_hi(3),nc_r)
+    double precision, intent (inout) :: rho_odot(r_lo(1):r_hi(1),r_lo(2):r_hi(2),r_lo(3):r_hi(3),nspec)
     double precision, intent (inout) :: rho_Hnuc(n_lo(1):n_hi(1),n_lo(2):n_hi(2),n_lo(3):n_hi(3))
     integer         , intent (in   ) :: t_lo(3), t_hi(3)
     double precision, intent (in   ) :: tempbar_init_cart(t_lo(1):t_hi(1),t_lo(2):t_hi(2),t_lo(3):t_hi(3))

--- a/Source/Src_nd/burner_loop.F90
+++ b/Source/Src_nd/burner_loop.F90
@@ -210,6 +210,8 @@ contains
 
     type (burn_t)    :: state_in, state_out
 
+    !$gpu
+
     if (firstCall) then
        ispec_threshold = network_species_index(burner_threshold_species)
        firstCall = .false.

--- a/Source/Src_nd/burner_loop.f90
+++ b/Source/Src_nd/burner_loop.f90
@@ -20,7 +20,8 @@ module burner_loop_module
 
 contains
 
-  subroutine burner_loop(lev, lo, hi, &
+  subroutine burner_loop(lo, hi, &
+       lev, &
        s_in,     i_lo, i_hi, nc_i, &
        s_out,    o_lo, o_hi, nc_o, &
        rho_Hext, e_lo, e_hi, &
@@ -30,7 +31,8 @@ contains
        mask,     m_lo, m_hi, use_mask) &
        bind (C,name="burner_loop")
 
-    integer         , intent (in   ) :: lev, lo(3), hi(3)
+    integer         , intent (in   ) :: lo(3), hi(3)
+    integer, value  , intent (in   ) :: lev
     integer         , intent (in   ) :: i_lo(3), i_hi(3), nc_i
     integer         , intent (in   ) :: o_lo(3), o_hi(3), nc_o
     integer         , intent (in   ) :: e_lo(3), e_hi(3)
@@ -43,9 +45,9 @@ contains
     double precision, intent (inout) :: rho_odot(r_lo(1):r_hi(1),r_lo(2):r_hi(2),r_lo(3):r_hi(3),nc_r)
     double precision, intent (inout) :: rho_Hnuc(n_lo(1):n_hi(1),n_lo(2):n_hi(2),n_lo(3):n_hi(3))
     double precision, intent (in   ) :: tempbar_init_in(0:max_radial_level,0:nr_fine-1)
-    double precision, intent (in   ) :: dt_in
+    double precision, value, intent (in) :: dt_in
     integer         , intent (in   ) :: mask(m_lo(1):m_hi(1),m_lo(2):m_hi(2),m_lo(3):m_hi(3))
-    integer         , intent (in   ) :: use_mask
+    integer, value  , intent (in   ) :: use_mask
 
     ! local
     integer          :: i, j, k, n
@@ -60,6 +62,8 @@ contains
     double precision :: sumX
 
     type (burn_t)    :: state_in, state_out
+
+    !$gpu
 
     if (firstCall) then
        ispec_threshold = network_species_index(burner_threshold_species)
@@ -188,9 +192,9 @@ contains
     double precision, intent (inout) :: rho_Hnuc(n_lo(1):n_hi(1),n_lo(2):n_hi(2),n_lo(3):n_hi(3))
     integer         , intent (in   ) :: t_lo(3), t_hi(3)
     double precision, intent (in   ) :: tempbar_init_cart(t_lo(1):t_hi(1),t_lo(2):t_hi(2),t_lo(3):t_hi(3))
-    double precision, intent (in   ) :: dt_in
+    double precision, value, intent (in) :: dt_in
     integer         , intent (in   ) :: mask(m_lo(1):m_hi(1),m_lo(2):m_hi(2),m_lo(3):m_hi(3))
-    integer         , intent (in   ) :: use_mask
+    integer, value  , intent (in   ) :: use_mask
 
     ! local
     integer          :: i, j, k, n

--- a/Source/Src_nd/maestro_init.f90
+++ b/Source/Src_nd/maestro_init.f90
@@ -19,9 +19,11 @@ contains
   subroutine maestro_network_init() bind(C, name="maestro_network_init")
 
     use actual_rhs_module, only: actual_rhs_init
+    use burner_loop_module, only: burner_loop_init
 
     call network_init()
     call actual_rhs_init()
+    call burner_loop_init()
 
   end subroutine maestro_network_init
 

--- a/Source/Src_nd/make_explicit_thermal.F90
+++ b/Source/Src_nd/make_explicit_thermal.F90
@@ -4,7 +4,7 @@ module make_explicit_thermal_module
   use eos_module
   use conductivity_module
   use network, only: nspec
-  use meth_params_module, only: rho_comp, temp_comp, spec_comp, &
+  use meth_params_module, only: rho_comp, temp_comp, spec_comp, nscal, &
        buoyancy_cutoff_factor, base_cutoff_density, &
        limit_conductivity
   use amrex_constants_module
@@ -16,10 +16,10 @@ module make_explicit_thermal_module
 contains
 
   subroutine make_thermal_coeffs(lo, hi, &
-       scal, s_lo, s_hi, nc_s, &
+       scal, s_lo, s_hi, &
        Tcoeff, t_lo, t_hi, &
        hcoeff, h_lo, h_hi, &
-       Xkcoeff, xk_lo, xk_hi, nc_xk, &
+       Xkcoeff, xk_lo, xk_hi, &
        pcoeff, p_lo, p_hi) bind(C,name="make_thermal_coeffs")
 
     ! create the coefficients for grad{T}, grad{h}, grad{X_k}, and grad{p_0}
@@ -28,14 +28,14 @@ contains
     ! note: we explicitly fill the ghostcells by looping over them directly
 
     integer         , intent(in   ) :: lo(3), hi(3)
-    integer         , intent(in   ) :: s_lo(3), s_hi(3), nc_s
-    double precision, intent(in   ) :: scal(s_lo(1):s_hi(1),s_lo(2):s_hi(2),s_lo(3):s_hi(3),nc_s)
+    integer         , intent(in   ) :: s_lo(3), s_hi(3)
+    double precision, intent(in   ) :: scal(s_lo(1):s_hi(1),s_lo(2):s_hi(2),s_lo(3):s_hi(3),nscal)
     integer         , intent(in   ) :: t_lo(3), t_hi(3)
     double precision, intent(inout) :: Tcoeff(t_lo(1):t_hi(1),t_lo(2):t_hi(2),t_lo(3):t_hi(3))
     integer         , intent(in   ) :: h_lo(3), h_hi(3)
     double precision, intent(inout) :: hcoeff(h_lo(1):h_hi(1),h_lo(2):h_hi(2),h_lo(3):h_hi(3))
-    integer         , intent(in   ) :: xk_lo(3), xk_hi(3), nc_xk
-    double precision, intent(inout) :: Xkcoeff(xk_lo(1):xk_hi(1),xk_lo(2):xk_hi(2),xk_lo(3):xk_hi(3),nc_xk)
+    integer         , intent(in   ) :: xk_lo(3), xk_hi(3)
+    double precision, intent(inout) :: Xkcoeff(xk_lo(1):xk_hi(1),xk_lo(2):xk_hi(2),xk_lo(3):xk_hi(3),nspec)
     integer         , intent(in   ) :: p_lo(3), p_hi(3)
     double precision, intent(inout) :: pcoeff(p_lo(1):p_hi(1),p_lo(2):p_hi(2),p_lo(3):p_hi(3))
 

--- a/Source/Src_nd/make_explicit_thermal.F90
+++ b/Source/Src_nd/make_explicit_thermal.F90
@@ -43,6 +43,8 @@ contains
     integer :: i,j,k,comp
     type (eos_t) :: eos_state
 
+    !$gpu
+
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     ! create Tcoeff = -kth,
     !        hcoeff = -kth/cp,
@@ -51,16 +53,9 @@ contains
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     !print *, "... Level ", lev, " create thermal coeffs:"
 
-
-    k = lo(3)
-    j = lo(2)
-#if (AMREX_SPACEDIM == 3)
-    do k=lo(3)-1,hi(3)+1
-#endif
-#if (AMREX_SPACEDIM >= 2)
-       do j=lo(2)-1,hi(2)+1
-#endif
-          do i=lo(1)-1,hi(1)+1
+    do k=lo(3),hi(3)
+       do j=lo(2),hi(2)
+          do i=lo(1),hi(1)
 
              ! if we are outside the star, turn off the conductivity
              if (limit_conductivity .and. &
@@ -95,12 +90,8 @@ contains
              endif
 
           enddo
-#if (AMREX_SPACEDIM >= 2)
        enddo
-#endif
-#if (AMREX_SPACEDIM == 3)
     enddo
-#endif
 
   end subroutine make_thermal_coeffs
 

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -12,6 +12,12 @@ int main(int argc, char* argv[])
 	// in AMReX.cpp
 	Initialize(argc,argv);
 
+#ifdef AMREX_USE_CUDA
+    // turn off GPU in main program
+    // only turn on GPU around appropriate subroutines
+    Cuda::setLaunchRegion(false);
+#endif
+
 	// Refuse to continue if we did not provide an inputs file.
 
 	if (argc <= 1) {

--- a/Source/param/meth_params.template
+++ b/Source/param/meth_params.template
@@ -12,10 +12,22 @@ module meth_params_module
 
   ! variables in the module
 
-  integer, save :: rho_comp, rhoh_comp, spec_comp, temp_comp, pi_comp
-  integer, save :: nscal
-  double precision, save :: prob_lo(3), prob_hi(3)
-  double precision, save :: rel_eps
+  integer, allocatable, save :: rho_comp, rhoh_comp, spec_comp, temp_comp, pi_comp
+  integer, allocatable, save :: nscal
+  double precision, allocatable, save :: prob_lo(:), prob_hi(:)
+  double precision, allocatable, save :: rel_eps
+
+#ifdef AMREX_USE_CUDA
+    attributes(managed) :: rho_comp
+    attributes(managed) :: rhoh_comp
+    attributes(managed) :: spec_comp
+    attributes(managed) :: temp_comp
+    attributes(managed) :: pi_comp
+    attributes(managed) :: nscal
+    attributes(managed) :: prob_lo
+    attributes(managed) :: prob_hi
+    attributes(managed) :: rel_eps
+#endif
 
 
   ! Begin the declarations of the ParmParse parameters
@@ -36,6 +48,12 @@ contains
     implicit none
 
     type (amrex_parmparse) :: pp
+
+    allocate(rho_comp, rhoh_comp, spec_comp, temp_comp, pi_comp)
+    allocate(nscal)
+    allocate(prob_lo(3))
+    allocate(prob_hi(3))
+    allocate(rel_eps)
 
     @@set_maestro_params@@
 
@@ -61,6 +79,11 @@ contains
 
   subroutine finalize_meth_params() bind(C, name="finalize_meth_params")
     implicit none
+
+    deallocate(rho_comp, rhoh_comp, spec_comp, temp_comp, pi_comp)
+    deallocate(nscal)
+    deallocate(prob_lo, prob_hi)
+    deallocate(rel_eps)
 
     @@free_maestro_params@@
 

--- a/Source/param/meth_params.template
+++ b/Source/param/meth_params.template
@@ -1,4 +1,4 @@
-! This module stores the runtime parameters and integer names for 
+! This module stores the runtime parameters and integer names for
 ! indexing arrays.
 !
 ! The Fortran-specific parameters are initialized in set_method_params(),
@@ -63,7 +63,7 @@ contains
     implicit none
 
     @@free_maestro_params@@
-    
+
   end subroutine finalize_meth_params
 
 end module meth_params_module

--- a/Source/param/parse_maestro_params.py
+++ b/Source/param/parse_maestro_params.py
@@ -204,6 +204,8 @@ class Param(object):
         # to 1, and the Fortran parmparse will resize
         if self.dtype == "string":
             ostr += "    allocate(character(len=1)::{})\n".format(name)
+        else:
+            ostr += "    allocate({})\n".format(name)
 
         if not self.debug_default is None:
             ostr += "#ifdef AMREX_DEBUG\n"
@@ -408,7 +410,7 @@ def write_meth_module(plist, meth_template):
 
         elif line.find("@@free_maestro_params@@") >= 0:
 
-            params_free = [q for q in params if q.in_fortran == 1 and q.f90_dtype == "string"]
+            params_free = [q for q in params if q.in_fortran == 1]
 
             for p in params_free:
                 mo.write("    if (allocated({})) then\n".format(p.f90_name))

--- a/Source/param/parse_maestro_params.py
+++ b/Source/param/parse_maestro_params.py
@@ -275,17 +275,32 @@ class Param(object):
             return None
 
         if self.f90_dtype == "int":
-            tstr = "integer                       , save :: {}\n".format(self.f90_name)
+            tstr = "integer          , allocatable, save :: {}\n".format(self.f90_name)
         elif self.f90_dtype == "Real":
-            tstr = "double precision              , save :: {}\n".format(self.f90_name)
+            tstr = "double precision , allocatable, save :: {}\n".format(self.f90_name)
         elif self.f90_dtype == "bool":
-            tstr = "logical                       , save :: {}\n".format(self.f90_name)
+            tstr = "logical          , allocatable, save :: {}\n".format(self.f90_name)
         elif self.f90_dtype == "string":
             tstr = "character (len=:), allocatable, save :: {}\n".format(self.f90_name)
+            print("warning: string parameter {} will not be available on the GPU".format(
+                self.f90_name))
         else:
             sys.exit("unsupported datatype for Fortran: {}".format(self.name))
 
         return tstr
+
+    def get_cuda_managed_string(self):
+        """this is the string that sets the variable as managed for CUDA"""
+        if self.f90_dtype == "string":
+            return "\n"
+        else:
+            cstr = ""
+            if self.ifdef is not None:
+                cstr += "#ifdef {}\n".format(self.ifdef)
+            cstr += "  attributes(managed) :: {}\n".format(self.f90_name)
+            if self.ifdef is not None:
+                cstr += "#endif\n"
+            return cstr
 
 
 def write_meth_module(plist, meth_template):
@@ -313,9 +328,22 @@ def write_meth_module(plist, meth_template):
     for p in param_decls:
         decls += "  {}".format(p)
 
+    cuda_managed_decls = [p.get_cuda_managed_string() for p in plist if p.in_fortran == 1]
+
+    cuda_managed_string = ""
+    for p in cuda_managed_decls:
+        cuda_managed_string += "{}".format(p)
+
     for line in mt:
         if line.find("@@f90_declarations@@") > 0:
             mo.write(decls)
+
+            # Do the CUDA managed declarations
+
+            mo.write("\n")
+            mo.write("#ifdef AMREX_USE_CUDA\n")
+            mo.write(cuda_managed_string)
+            mo.write("#endif\n")
 
             # Now do the OpenACC declarations
 

--- a/Source/param/runtime.probin.template
+++ b/Source/param/runtime.probin.template
@@ -31,10 +31,6 @@ module extern_probin_module
 
   @@declarationsB@@
 
-#ifdef AMREX_USE_CUDA
-  @@cudaattributesB@@
-#endif
-
 end module extern_probin_module
 
 

--- a/Source/param/runtime.probin.template
+++ b/Source/param/runtime.probin.template
@@ -71,7 +71,7 @@ subroutine runtime_init()
   if (status .ne. 0) then
      ! some problem in the namelist
      print *, 'ERROR: problem in the namelist'
-     stop
+     !stop
   endif
 
   @@acc@@

--- a/Source/param/runtime.probin.template
+++ b/Source/param/runtime.probin.template
@@ -31,6 +31,10 @@ module extern_probin_module
 
   @@declarationsB@@
 
+#ifdef AMREX_USE_CUDA
+  @@cudaattributesB@@
+#endif
+
 end module extern_probin_module
 
 

--- a/Source/param/runtime.probin.template
+++ b/Source/param/runtime.probin.template
@@ -14,7 +14,7 @@ module probin_module
 
   @@declarationsA@@
 
-#ifdef CUDA
+#ifdef AMREX_USE_CUDA
   @@cudaattributesA@@
 #endif
 
@@ -31,7 +31,7 @@ module extern_probin_module
 
   @@declarationsB@@
 
-#ifdef CUDA
+#ifdef AMREX_USE_CUDA
   @@cudaattributesB@@
 #endif
 
@@ -63,6 +63,8 @@ subroutine runtime_init()
   implicit none
 
   integer :: status
+
+  @@allocations@@
 
   @@defaults@@
 

--- a/Source/param_includes/meth_params.F90
+++ b/Source/param_includes/meth_params.F90
@@ -3,7 +3,7 @@
 ! or add runtime parameters, please edit _cpp_parameters and then run
 ! mk_params.sh
 
-! This module stores the runtime parameters and integer names for 
+! This module stores the runtime parameters and integer names for
 ! indexing arrays.
 !
 ! The Fortran-specific parameters are initialized in set_method_params(),
@@ -25,62 +25,121 @@ module meth_params_module
 
   ! Begin the declarations of the ParmParse parameters
 
-  integer                       , save :: maestro_verbose
+  integer          , allocatable, save :: maestro_verbose
   character (len=:), allocatable, save :: model_file
-  logical                       , save :: perturb_model
-  logical                       , save :: print_init_hse_diag
-  double precision              , save :: cfl
-  logical                       , save :: use_soundspeed_firstdt
-  logical                       , save :: use_divu_firstdt
-  integer                       , save :: spherical
-  logical                       , save :: octant
-  integer                       , save :: do_2d_planar_octant
-  integer                       , save :: drdxfac
-  logical                       , save :: use_tpert_in_tagging
-  logical                       , save :: do_sponge
-  double precision              , save :: sponge_kappa
-  double precision              , save :: sponge_center_density
-  double precision              , save :: sponge_start_factor
-  double precision              , save :: anelastic_cutoff_density
-  double precision              , save :: base_cutoff_density
-  double precision              , save :: burning_cutoff_density
-  double precision              , save :: buoyancy_cutoff_factor
-  double precision              , save :: dpdt_factor
-  logical                       , save :: do_planar_invsq_grav
-  double precision              , save :: planar_invsq_mass
-  logical                       , save :: evolve_base_state
-  logical                       , save :: use_exact_base_state
-  logical                       , save :: average_base_state
-  logical                       , save :: do_smallscale
-  logical                       , save :: do_eos_h_above_cutoff
-  integer                       , save :: enthalpy_pred_type
-  integer                       , save :: species_pred_type
-  logical                       , save :: use_delta_gamma1_term
-  integer                       , save :: slope_order
-  double precision              , save :: grav_const
-  integer                       , save :: ppm_type
-  integer                       , save :: ppm_trace_forces
-  integer                       , save :: beta0_type
-  logical                       , save :: use_linear_grav_in_beta0
-  double precision              , save :: rotational_frequency
-  double precision              , save :: co_latitude
-  logical                       , save :: drive_initial_convection
-  logical                       , save :: use_alt_energy_fix
-  integer                       , save :: temp_diffusion_formulation
-  integer                       , save :: thermal_diffusion_type
-  logical                       , save :: limit_conductivity
+  logical          , allocatable, save :: perturb_model
+  logical          , allocatable, save :: print_init_hse_diag
+  double precision , allocatable, save :: cfl
+  logical          , allocatable, save :: use_soundspeed_firstdt
+  logical          , allocatable, save :: use_divu_firstdt
+  integer          , allocatable, save :: spherical
+  logical          , allocatable, save :: octant
+  integer          , allocatable, save :: do_2d_planar_octant
+  integer          , allocatable, save :: drdxfac
+  logical          , allocatable, save :: use_tpert_in_tagging
+  logical          , allocatable, save :: do_sponge
+  double precision , allocatable, save :: sponge_kappa
+  double precision , allocatable, save :: sponge_center_density
+  double precision , allocatable, save :: sponge_start_factor
+  double precision , allocatable, save :: anelastic_cutoff_density
+  double precision , allocatable, save :: base_cutoff_density
+  double precision , allocatable, save :: burning_cutoff_density
+  double precision , allocatable, save :: buoyancy_cutoff_factor
+  double precision , allocatable, save :: dpdt_factor
+  logical          , allocatable, save :: do_planar_invsq_grav
+  double precision , allocatable, save :: planar_invsq_mass
+  logical          , allocatable, save :: evolve_base_state
+  logical          , allocatable, save :: use_exact_base_state
+  logical          , allocatable, save :: average_base_state
+  logical          , allocatable, save :: do_smallscale
+  logical          , allocatable, save :: do_eos_h_above_cutoff
+  integer          , allocatable, save :: enthalpy_pred_type
+  integer          , allocatable, save :: species_pred_type
+  logical          , allocatable, save :: use_delta_gamma1_term
+  integer          , allocatable, save :: slope_order
+  double precision , allocatable, save :: grav_const
+  integer          , allocatable, save :: ppm_type
+  integer          , allocatable, save :: ppm_trace_forces
+  integer          , allocatable, save :: beta0_type
+  logical          , allocatable, save :: use_linear_grav_in_beta0
+  double precision , allocatable, save :: rotational_frequency
+  double precision , allocatable, save :: co_latitude
+  logical          , allocatable, save :: drive_initial_convection
+  logical          , allocatable, save :: use_alt_energy_fix
+  integer          , allocatable, save :: temp_diffusion_formulation
+  integer          , allocatable, save :: thermal_diffusion_type
+  logical          , allocatable, save :: limit_conductivity
   character (len=:), allocatable, save :: burner_threshold_species
-  double precision              , save :: burner_threshold_cutoff
-  double precision              , save :: reaction_sum_tol
-  double precision              , save :: small_temp
-  double precision              , save :: small_dens
-  logical                       , save :: use_eos_e_instead_of_h
-  logical                       , save :: use_pprime_in_tfromp
-  integer                       , save :: s0_interp_type
-  integer                       , save :: w0_interp_type
-  integer                       , save :: s0mac_interp_type
-  integer                       , save :: w0mac_interp_type
-  integer                       , save :: track_grid_losses
+  double precision , allocatable, save :: burner_threshold_cutoff
+  double precision , allocatable, save :: reaction_sum_tol
+  double precision , allocatable, save :: small_temp
+  double precision , allocatable, save :: small_dens
+  logical          , allocatable, save :: use_eos_e_instead_of_h
+  logical          , allocatable, save :: use_pprime_in_tfromp
+  integer          , allocatable, save :: s0_interp_type
+  integer          , allocatable, save :: w0_interp_type
+  integer          , allocatable, save :: s0mac_interp_type
+  integer          , allocatable, save :: w0mac_interp_type
+  integer          , allocatable, save :: track_grid_losses
+
+#ifdef AMREX_USE_CUDA
+  attributes(managed) :: maestro_verbose
+
+  attributes(managed) :: perturb_model
+  attributes(managed) :: print_init_hse_diag
+  attributes(managed) :: cfl
+  attributes(managed) :: use_soundspeed_firstdt
+  attributes(managed) :: use_divu_firstdt
+  attributes(managed) :: spherical
+  attributes(managed) :: octant
+  attributes(managed) :: do_2d_planar_octant
+  attributes(managed) :: drdxfac
+  attributes(managed) :: use_tpert_in_tagging
+  attributes(managed) :: do_sponge
+  attributes(managed) :: sponge_kappa
+  attributes(managed) :: sponge_center_density
+  attributes(managed) :: sponge_start_factor
+  attributes(managed) :: anelastic_cutoff_density
+  attributes(managed) :: base_cutoff_density
+  attributes(managed) :: burning_cutoff_density
+  attributes(managed) :: buoyancy_cutoff_factor
+  attributes(managed) :: dpdt_factor
+  attributes(managed) :: do_planar_invsq_grav
+  attributes(managed) :: planar_invsq_mass
+  attributes(managed) :: evolve_base_state
+  attributes(managed) :: use_exact_base_state
+  attributes(managed) :: average_base_state
+  attributes(managed) :: do_smallscale
+  attributes(managed) :: do_eos_h_above_cutoff
+  attributes(managed) :: enthalpy_pred_type
+  attributes(managed) :: species_pred_type
+  attributes(managed) :: use_delta_gamma1_term
+  attributes(managed) :: slope_order
+  attributes(managed) :: grav_const
+  attributes(managed) :: ppm_type
+  attributes(managed) :: ppm_trace_forces
+  attributes(managed) :: beta0_type
+  attributes(managed) :: use_linear_grav_in_beta0
+  attributes(managed) :: rotational_frequency
+  attributes(managed) :: co_latitude
+  attributes(managed) :: drive_initial_convection
+  attributes(managed) :: use_alt_energy_fix
+  attributes(managed) :: temp_diffusion_formulation
+  attributes(managed) :: thermal_diffusion_type
+  attributes(managed) :: limit_conductivity
+
+  attributes(managed) :: burner_threshold_cutoff
+  attributes(managed) :: reaction_sum_tol
+  attributes(managed) :: small_temp
+  attributes(managed) :: small_dens
+  attributes(managed) :: use_eos_e_instead_of_h
+  attributes(managed) :: use_pprime_in_tfromp
+  attributes(managed) :: s0_interp_type
+  attributes(managed) :: w0_interp_type
+  attributes(managed) :: s0mac_interp_type
+  attributes(managed) :: w0mac_interp_type
+  attributes(managed) :: track_grid_losses
+#endif
 
   ! End the declarations of the ParmParse parameters
 
@@ -248,7 +307,7 @@ contains
     end if
 
 
-    
+
   end subroutine finalize_meth_params
 
 end module meth_params_module

--- a/Source/param_includes/meth_params.F90
+++ b/Source/param_includes/meth_params.F90
@@ -17,10 +17,22 @@ module meth_params_module
 
   ! variables in the module
 
-  integer, save :: rho_comp, rhoh_comp, spec_comp, temp_comp, pi_comp
-  integer, save :: nscal
-  double precision, save :: prob_lo(3), prob_hi(3)
-  double precision, save :: rel_eps
+  integer, allocatable, save :: rho_comp, rhoh_comp, spec_comp, temp_comp, pi_comp
+  integer, allocatable, save :: nscal
+  double precision, allocatable, save :: prob_lo(:), prob_hi(:)
+  double precision, allocatable, save :: rel_eps
+
+#ifdef AMREX_USE_CUDA
+    attributes(managed) :: rho_comp
+    attributes(managed) :: rhoh_comp
+    attributes(managed) :: spec_comp
+    attributes(managed) :: temp_comp
+    attributes(managed) :: pi_comp
+    attributes(managed) :: nscal
+    attributes(managed) :: prob_lo
+    attributes(managed) :: prob_hi
+    attributes(managed) :: rel_eps
+#endif
 
 
   ! Begin the declarations of the ParmParse parameters
@@ -156,63 +168,123 @@ contains
 
     type (amrex_parmparse) :: pp
 
+    allocate(rho_comp, rhoh_comp, spec_comp, temp_comp, pi_comp)
+    allocate(nscal)
+    allocate(prob_lo(3))
+    allocate(prob_hi(3))
+    allocate(rel_eps)
+
+    allocate(maestro_verbose)
     maestro_verbose = 1;
     allocate(character(len=1)::model_file)
     model_file = "";
+    allocate(perturb_model)
     perturb_model = .false.;
+    allocate(print_init_hse_diag)
     print_init_hse_diag = .false.;
+    allocate(cfl)
     cfl = 0.5d0;
+    allocate(use_soundspeed_firstdt)
     use_soundspeed_firstdt = .false.;
+    allocate(use_divu_firstdt)
     use_divu_firstdt = .false.;
+    allocate(spherical)
     spherical = 0;
+    allocate(octant)
     octant = .false.;
+    allocate(do_2d_planar_octant)
     do_2d_planar_octant = 0;
+    allocate(drdxfac)
     drdxfac = 1;
+    allocate(use_tpert_in_tagging)
     use_tpert_in_tagging = .false.;
+    allocate(do_sponge)
     do_sponge = .false.;
+    allocate(sponge_kappa)
     sponge_kappa = 10.d0;
+    allocate(sponge_center_density)
     sponge_center_density = 3.d6;
+    allocate(sponge_start_factor)
     sponge_start_factor = 3.333d0;
+    allocate(anelastic_cutoff_density)
     anelastic_cutoff_density = -1.0d0;
+    allocate(base_cutoff_density)
     base_cutoff_density = -1.0d0;
+    allocate(burning_cutoff_density)
     burning_cutoff_density = -1.0d0;
+    allocate(buoyancy_cutoff_factor)
     buoyancy_cutoff_factor = 5.0d0;
+    allocate(dpdt_factor)
     dpdt_factor = 0.0d0;
+    allocate(do_planar_invsq_grav)
     do_planar_invsq_grav = .false.;
+    allocate(planar_invsq_mass)
     planar_invsq_mass = 0.0d0;
+    allocate(evolve_base_state)
     evolve_base_state = .true.;
+    allocate(use_exact_base_state)
     use_exact_base_state = .false.;
+    allocate(average_base_state)
     average_base_state = .false.;
+    allocate(do_smallscale)
     do_smallscale = .false.;
+    allocate(do_eos_h_above_cutoff)
     do_eos_h_above_cutoff = .true.;
+    allocate(enthalpy_pred_type)
     enthalpy_pred_type = 1;
+    allocate(species_pred_type)
     species_pred_type = 1;
+    allocate(use_delta_gamma1_term)
     use_delta_gamma1_term = .false.;
+    allocate(slope_order)
     slope_order = 4;
+    allocate(grav_const)
     grav_const = -1.5d10;
+    allocate(ppm_type)
     ppm_type = 1;
+    allocate(ppm_trace_forces)
     ppm_trace_forces = 0;
+    allocate(beta0_type)
     beta0_type = 1;
+    allocate(use_linear_grav_in_beta0)
     use_linear_grav_in_beta0 = .false.;
+    allocate(rotational_frequency)
     rotational_frequency = 0.0d0;
+    allocate(co_latitude)
     co_latitude = 0.0d0;
+    allocate(drive_initial_convection)
     drive_initial_convection = .false.;
+    allocate(use_alt_energy_fix)
     use_alt_energy_fix = .true.;
+    allocate(temp_diffusion_formulation)
     temp_diffusion_formulation = 2;
+    allocate(thermal_diffusion_type)
     thermal_diffusion_type = 1;
+    allocate(limit_conductivity)
     limit_conductivity = .false.;
     allocate(character(len=1)::burner_threshold_species)
     burner_threshold_species = "";
+    allocate(burner_threshold_cutoff)
     burner_threshold_cutoff = 1.d-10;
+    allocate(reaction_sum_tol)
     reaction_sum_tol = 1.d-10;
+    allocate(small_temp)
     small_temp = 5.d6;
+    allocate(small_dens)
     small_dens = 1.d-5;
+    allocate(use_eos_e_instead_of_h)
     use_eos_e_instead_of_h = .false.;
+    allocate(use_pprime_in_tfromp)
     use_pprime_in_tfromp = .false.;
+    allocate(s0_interp_type)
     s0_interp_type = 3;
+    allocate(w0_interp_type)
     w0_interp_type = 2;
+    allocate(s0mac_interp_type)
     s0mac_interp_type = 1;
+    allocate(w0mac_interp_type)
     w0mac_interp_type = 1;
+    allocate(track_grid_losses)
     track_grid_losses = 0;
 
     call amrex_parmparse_build(pp, "maestro")
@@ -299,11 +371,178 @@ contains
   subroutine finalize_meth_params() bind(C, name="finalize_meth_params")
     implicit none
 
+    deallocate(rho_comp, rhoh_comp, spec_comp, temp_comp, pi_comp)
+    deallocate(nscal)
+    deallocate(prob_lo, prob_hi)
+    deallocate(rel_eps)
+
+    if (allocated(maestro_verbose)) then
+        deallocate(maestro_verbose)
+    end if
     if (allocated(model_file)) then
         deallocate(model_file)
     end if
+    if (allocated(perturb_model)) then
+        deallocate(perturb_model)
+    end if
+    if (allocated(print_init_hse_diag)) then
+        deallocate(print_init_hse_diag)
+    end if
+    if (allocated(cfl)) then
+        deallocate(cfl)
+    end if
+    if (allocated(use_soundspeed_firstdt)) then
+        deallocate(use_soundspeed_firstdt)
+    end if
+    if (allocated(use_divu_firstdt)) then
+        deallocate(use_divu_firstdt)
+    end if
+    if (allocated(spherical)) then
+        deallocate(spherical)
+    end if
+    if (allocated(octant)) then
+        deallocate(octant)
+    end if
+    if (allocated(do_2d_planar_octant)) then
+        deallocate(do_2d_planar_octant)
+    end if
+    if (allocated(drdxfac)) then
+        deallocate(drdxfac)
+    end if
+    if (allocated(use_tpert_in_tagging)) then
+        deallocate(use_tpert_in_tagging)
+    end if
+    if (allocated(do_sponge)) then
+        deallocate(do_sponge)
+    end if
+    if (allocated(sponge_kappa)) then
+        deallocate(sponge_kappa)
+    end if
+    if (allocated(sponge_center_density)) then
+        deallocate(sponge_center_density)
+    end if
+    if (allocated(sponge_start_factor)) then
+        deallocate(sponge_start_factor)
+    end if
+    if (allocated(anelastic_cutoff_density)) then
+        deallocate(anelastic_cutoff_density)
+    end if
+    if (allocated(base_cutoff_density)) then
+        deallocate(base_cutoff_density)
+    end if
+    if (allocated(burning_cutoff_density)) then
+        deallocate(burning_cutoff_density)
+    end if
+    if (allocated(buoyancy_cutoff_factor)) then
+        deallocate(buoyancy_cutoff_factor)
+    end if
+    if (allocated(dpdt_factor)) then
+        deallocate(dpdt_factor)
+    end if
+    if (allocated(do_planar_invsq_grav)) then
+        deallocate(do_planar_invsq_grav)
+    end if
+    if (allocated(planar_invsq_mass)) then
+        deallocate(planar_invsq_mass)
+    end if
+    if (allocated(evolve_base_state)) then
+        deallocate(evolve_base_state)
+    end if
+    if (allocated(use_exact_base_state)) then
+        deallocate(use_exact_base_state)
+    end if
+    if (allocated(average_base_state)) then
+        deallocate(average_base_state)
+    end if
+    if (allocated(do_smallscale)) then
+        deallocate(do_smallscale)
+    end if
+    if (allocated(do_eos_h_above_cutoff)) then
+        deallocate(do_eos_h_above_cutoff)
+    end if
+    if (allocated(enthalpy_pred_type)) then
+        deallocate(enthalpy_pred_type)
+    end if
+    if (allocated(species_pred_type)) then
+        deallocate(species_pred_type)
+    end if
+    if (allocated(use_delta_gamma1_term)) then
+        deallocate(use_delta_gamma1_term)
+    end if
+    if (allocated(slope_order)) then
+        deallocate(slope_order)
+    end if
+    if (allocated(grav_const)) then
+        deallocate(grav_const)
+    end if
+    if (allocated(ppm_type)) then
+        deallocate(ppm_type)
+    end if
+    if (allocated(ppm_trace_forces)) then
+        deallocate(ppm_trace_forces)
+    end if
+    if (allocated(beta0_type)) then
+        deallocate(beta0_type)
+    end if
+    if (allocated(use_linear_grav_in_beta0)) then
+        deallocate(use_linear_grav_in_beta0)
+    end if
+    if (allocated(rotational_frequency)) then
+        deallocate(rotational_frequency)
+    end if
+    if (allocated(co_latitude)) then
+        deallocate(co_latitude)
+    end if
+    if (allocated(drive_initial_convection)) then
+        deallocate(drive_initial_convection)
+    end if
+    if (allocated(use_alt_energy_fix)) then
+        deallocate(use_alt_energy_fix)
+    end if
+    if (allocated(temp_diffusion_formulation)) then
+        deallocate(temp_diffusion_formulation)
+    end if
+    if (allocated(thermal_diffusion_type)) then
+        deallocate(thermal_diffusion_type)
+    end if
+    if (allocated(limit_conductivity)) then
+        deallocate(limit_conductivity)
+    end if
     if (allocated(burner_threshold_species)) then
         deallocate(burner_threshold_species)
+    end if
+    if (allocated(burner_threshold_cutoff)) then
+        deallocate(burner_threshold_cutoff)
+    end if
+    if (allocated(reaction_sum_tol)) then
+        deallocate(reaction_sum_tol)
+    end if
+    if (allocated(small_temp)) then
+        deallocate(small_temp)
+    end if
+    if (allocated(small_dens)) then
+        deallocate(small_dens)
+    end if
+    if (allocated(use_eos_e_instead_of_h)) then
+        deallocate(use_eos_e_instead_of_h)
+    end if
+    if (allocated(use_pprime_in_tfromp)) then
+        deallocate(use_pprime_in_tfromp)
+    end if
+    if (allocated(s0_interp_type)) then
+        deallocate(s0_interp_type)
+    end if
+    if (allocated(w0_interp_type)) then
+        deallocate(w0_interp_type)
+    end if
+    if (allocated(s0mac_interp_type)) then
+        deallocate(s0mac_interp_type)
+    end if
+    if (allocated(w0mac_interp_type)) then
+        deallocate(w0mac_interp_type)
+    end if
+    if (allocated(track_grid_losses)) then
+        deallocate(track_grid_losses)
     end if
 
 


### PR DESCRIPTION
This offloads a few routines to gpu and amends the python script that generates `meth_params.F90` so that it marks variables and managed attributes and allocates/deallocates them. 

I've tested the gpu version against a serial version (both compiled with PGI and VODE90) on bender for reacting_bubble, double_bubble and test_convect, and the results appear to agree to within an acceptable degree of error. 