### PR TITLE
Bug fix for use_exact_base_state

### DIFF
--- a/Source/MaestroInit.cpp
+++ b/Source/MaestroInit.cpp
@@ -75,8 +75,8 @@ Maestro::Init ()
             }
             pi[lev].define(convert(grids[lev],nodal_flag), dmap[lev], 1, 0); // nodal
 #ifdef SDC
-	    intra[lev].define(grids[lev], dmap[lev], Nscal, 0); // for sdc
-	    intra[lev].setVal(0.);
+            intra[lev].define(grids[lev], dmap[lev], Nscal, 0); // for sdc
+            intra[lev].setVal(0.);
 #endif
         }
 

--- a/Source/MaestroInit.cpp
+++ b/Source/MaestroInit.cpp
@@ -480,6 +480,8 @@ void Maestro::InitProj ()
     if (evolve_base_state && (use_exact_base_state == 0 && average_base_state == 0)) {
         // average S into Sbar
         Average(S_cc_old,Sbar,0);
+    } else {
+        std::fill(Sbar.begin(), Sbar.end(), 0.);
     }
 
     // make the nodal rhs for projection beta0*(S_cc-Sbar) + beta0*delta_chi

--- a/Source/Src_nd/base_state_geometry.F90
+++ b/Source/Src_nd/base_state_geometry.F90
@@ -137,11 +137,11 @@ contains
        if (use_exact_base_state) then
           ! nr_fine = nr_irreg + 1
           do i=0,nr_fine-1
-             r_cc_loc(0,i) = sqrt(0.75d0+2.d0*i)*dx_fine(0)
+             r_cc_loc(0,i) = sqrt(0.75d0+2.d0*dble(i))*dx_fine(0)
           end do
           r_edge_loc(0,0) = 0.d0
           do i=0,nr_fine-1
-             r_edge_loc(0,i+1) = sqrt(0.75d0+2.d0*(i+0.5d0))*dx_fine(0)
+             r_edge_loc(0,i+1) = sqrt(0.75d0+2.d0*(dble(i)+0.5d0))*dx_fine(0)
           end do
        else
           do i=0,nr_fine-1

--- a/Source/Src_nd/fill_3d_data.F90
+++ b/Source/Src_nd/fill_3d_data.F90
@@ -131,7 +131,11 @@ contains
                       radius = sqrt(x**2 + y**2 + z**2)
                       index = cc_to_r(i,j,k)
 
-                      rfac = (radius - r_edge_loc(0,index+1)) / (r_cc_loc(0,index+1) - r_cc_loc(0,index))
+                      if (index .lt. nr_fine) then 
+                        rfac = (radius - r_edge_loc(0,index+1)) / (r_cc_loc(0,index+1) - r_cc_loc(0,index))
+                      else 
+                        rfac = (radius - r_edge_loc(0,index+1)) / (r_cc_loc(0,index) - r_cc_loc(0,index-1))
+                      endif
 
                       if (rfac .gt. 0.5d0) then
                          s0_cart_val = s0(0,index+1)
@@ -161,7 +165,11 @@ contains
                       radius = sqrt(x**2 + y**2 + z**2)
                       index  = cc_to_r(i,j,k)
 
-                      rfac = (radius - r_edge_loc(0,index+1)) / (r_cc_loc(0,index+1) - r_cc_loc(0,index))
+                      if (index .lt. nr_fine-1) then 
+                        rfac = (radius - r_edge_loc(0,index+1)) / (r_cc_loc(0,index+1) - r_cc_loc(0,index))
+                      else 
+                        rfac = (radius - r_edge_loc(0,index+1)) / (r_cc_loc(0,index) - r_cc_loc(0,index-1))
+                      endif
 
                       if (index .lt. nr_fine) then
                          s0_cart_val = rfac * s0(0,index+1) + (ONE-rfac) * s0(0,index)

--- a/Source/Src_nd/make_beta0.F90
+++ b/Source/Src_nd/make_beta0.F90
@@ -346,8 +346,13 @@ module make_beta0_module
                    
                 if (r < anelastic_cutoff_density_coord(n)) then
 
-                   drp = r_edge_loc(n,r+1) - r_edge_loc(n,r)
-                   drm = r_edge_loc(n,r) - r_edge_loc(n,r-1)
+                   if (r .gt. 0) then 
+                        drp = r_edge_loc(n,r+1) - r_edge_loc(n,r)
+                        drm = r_edge_loc(n,r) - r_edge_loc(n,r-1)
+                   else 
+                        drp = r_edge_loc(n,r+1) - r_edge_loc(n,r)
+                        drm = drp
+                   endif 
                    
                    if (r .eq. 0 .or. r .eq. nr(n)-1) then
                       


### PR DESCRIPTION
This fixes a bug which caused wdconvect to segfault when run with `use_exact_base_state` by ensuring that Sbar is initialized. 

It also fixes a couple of indexing bugs that were found when running with `amrex.fpe_trap_invalid`. 