### PR TITLE
this merges the _parameters into a single module

### DIFF
--- a/Exec/Make.Maestro
+++ b/Exec/Make.Maestro
@@ -226,7 +226,7 @@ extern.F90: $(PROBIN_PARAMETERS) $(PROBIN_TEMPLATE)
 	@echo "${bold}WRITING extern.F90${normal}"
 	$(AMREX_HOME)/Tools/F_scripts/write_probin.py \
           -t $(PROBIN_TEMPLATE) -o extern.F90 -n probin \
-          --pa "$(PROBIN_PARAMETERS)" --pb "$(EXTERN_PARAMETERS)" $(MANAGED_PROBIN_FLAG)
+          --pa "$(PROBIN_PARAMETERS) $(EXTERN_PARAMETERS)" $(MANAGED_PROBIN_FLAG)
 	@echo " "
 
 

--- a/Source/param/runtime.probin.template
+++ b/Source/param/runtime.probin.template
@@ -12,10 +12,10 @@ module probin_module
 
   private
 
-  @@declarationsA@@
+  @@declarations@@
 
 #ifdef AMREX_USE_CUDA
-  @@cudaattributesA@@
+  @@cudaattributes@@
 #endif
 
 end module probin_module
@@ -23,17 +23,9 @@ end module probin_module
 
 module extern_probin_module
 
-  use amrex_fort_module, only : rt => amrex_real
+  use probin_module
 
   implicit none
-
-  private
-
-  @@declarationsB@@
-
-#ifdef AMREX_USE_CUDA
-  @@cudaattributesB@@
-#endif
 
 end module extern_probin_module
 

--- a/Source/param/runtime.probin.template
+++ b/Source/param/runtime.probin.template
@@ -12,10 +12,10 @@ module probin_module
 
   private
 
-  @@declarations@@
+  @@declarationsA@@
 
 #ifdef AMREX_USE_CUDA
-  @@cudaattributes@@
+  @@cudaattributesA@@
 #endif
 
 end module probin_module


### PR DESCRIPTION
previously we had two sets of parameters, some lived in probin_module
and some in extern_probin_module, but they were initialized with the same
namelist.  This made the script more complicated to maintain.  Now all
the parameters live in probin_module and a stub extern_probin_module is
created that just `uses` probin_module to ensure the Microphysics works.