### PR TITLE
Fix non-deterministic OMP+MPI behavior

### DIFF
--- a/Source/MaestroMakeFlux.cpp
+++ b/Source/MaestroMakeFlux.cpp
@@ -72,13 +72,10 @@ Maestro::MakeRhoXFlux (const Vector<MultiFab>& state,
 
             // Get the index space of the valid region
             const Box& tileBox = mfi.tilebox();
-            const Box& xbx = amrex::growHi(tileBox,0, 1);
-            const Box& ybx = amrex::growHi(tileBox,1, 1);
-            // const Box& xbx = mfi.nodaltilebox(0);
-            // const Box& ybx = mfi.nodaltilebox(1);
+            const Box& xbx = mfi.nodaltilebox(0);
+            const Box& ybx = mfi.nodaltilebox(1);
 #if (AMREX_SPACEDIM == 3)
-            const Box& zbx = amrex::growHi(tileBox,2, 1);
-            // const Box& zbx = mfi.nodaltilebox(2);
+            const Box& zbx = mfi.nodaltilebox(2);
 #endif
 
             const Array4<Real> sedgex = sedge[lev][0].array(mfi);

--- a/Source/MaestroMakeUtrans.cpp
+++ b/Source/MaestroMakeUtrans.cpp
@@ -86,12 +86,10 @@ Maestro::MakeUtrans (const Vector<MultiFab>& utilde,
             const Box& tileBox = mfi.tilebox();
             const Box& obx = amrex::grow(tileBox, 1);
             const Box& xbx = mfi.nodaltilebox(0);
-            const Box& ybx = mfi.nodaltilebox(1);
 
             Array4<const Real> const utilde_arr = utilde[lev].array(mfi);
             Array4<const Real> const ufull_arr = ufull[lev].array(mfi);
             Array4<Real> const utrans_arr = utrans[lev][0].array(mfi);
-            Array4<Real> const vtrans_arr = utrans[lev][1].array(mfi);
             Array4<Real> const Im_arr = Im.array(mfi);
             Array4<Real> const Ip_arr = Ip.array(mfi);
             Array4<const Real> const w0_arr = w0_cart[lev].array(mfi);
@@ -194,12 +192,10 @@ Maestro::MakeUtrans (const Vector<MultiFab>& utilde,
             // Get the index space of the valid region
             const Box& tileBox = mfi.tilebox();
             const Box& obx = amrex::grow(tileBox, 1);
-            const Box& xbx = mfi.nodaltilebox(0);
             const Box& ybx = mfi.nodaltilebox(1);
 
             Array4<const Real> const utilde_arr = utilde[lev].array(mfi);
             Array4<const Real> const ufull_arr = ufull[lev].array(mfi);
-            Array4<Real> const utrans_arr = utrans[lev][0].array(mfi);
             Array4<Real> const vtrans_arr = utrans[lev][1].array(mfi);
             Array4<Real> const Im_arr = Im.array(mfi);
             Array4<Real> const Ip_arr = Ip.array(mfi);
@@ -306,20 +302,14 @@ Maestro::MakeUtrans (const Vector<MultiFab>& utilde,
             const Box& tileBox = mfi.tilebox();
             const Box& obx = amrex::grow(tileBox, 1);
             const Box& xbx = mfi.nodaltilebox(0);
-            const Box& ybx = mfi.nodaltilebox(1);
-            const Box& zbx = mfi.nodaltilebox(2);
 
             Array4<const Real> const utilde_arr = utilde[lev].array(mfi);
             Array4<const Real> const ufull_arr = ufull[lev].array(mfi);
             Array4<Real> const utrans_arr = utrans[lev][0].array(mfi);
-            Array4<Real> const vtrans_arr = utrans[lev][1].array(mfi);
-            Array4<Real> const wtrans_arr = utrans[lev][2].array(mfi);
             Array4<Real> const Im_arr = Im.array(mfi);
             Array4<Real> const Ip_arr = Ip.array(mfi);
             Array4<const Real> const w0_arr = w0_cart[lev].array(mfi);
             Array4<const Real> const w0macx = w0mac[lev][0].array(mfi);
-            Array4<const Real> const w0macy = w0mac[lev][1].array(mfi);
-            Array4<const Real> const w0macz = w0mac[lev][2].array(mfi);
 
             // x-direction
             if (ppm_type == 0) {
@@ -419,8 +409,6 @@ Maestro::MakeUtrans (const Vector<MultiFab>& utilde,
             });
         }
 
-        
-
 #ifdef _OPENMP
 #pragma omp parallel
 #endif
@@ -429,21 +417,15 @@ Maestro::MakeUtrans (const Vector<MultiFab>& utilde,
             // Get the index space of the valid region
             const Box& tileBox = mfi.tilebox();
             const Box& obx = amrex::grow(tileBox, 1);
-            const Box& xbx = mfi.nodaltilebox(0);
             const Box& ybx = mfi.nodaltilebox(1);
-            const Box& zbx = mfi.nodaltilebox(2);
 
             Array4<const Real> const utilde_arr = utilde[lev].array(mfi);
             Array4<const Real> const ufull_arr = ufull[lev].array(mfi);
-            Array4<Real> const utrans_arr = utrans[lev][0].array(mfi);
             Array4<Real> const vtrans_arr = utrans[lev][1].array(mfi);
-            Array4<Real> const wtrans_arr = utrans[lev][2].array(mfi);
             Array4<Real> const Im_arr = Im.array(mfi);
             Array4<Real> const Ip_arr = Ip.array(mfi);
             Array4<const Real> const w0_arr = w0_cart[lev].array(mfi);
-            Array4<const Real> const w0macx = w0mac[lev][0].array(mfi);
             Array4<const Real> const w0macy = w0mac[lev][1].array(mfi);
-            Array4<const Real> const w0macz = w0mac[lev][2].array(mfi);
 
             // y-direction
             if (ppm_type == 0) {
@@ -544,8 +526,6 @@ Maestro::MakeUtrans (const Vector<MultiFab>& utilde,
             });
         }
 
-        
-
 #ifdef _OPENMP
 #pragma omp parallel
 #endif
@@ -554,20 +534,14 @@ Maestro::MakeUtrans (const Vector<MultiFab>& utilde,
             // Get the index space of the valid region
             const Box& tileBox = mfi.tilebox();
             const Box& obx = amrex::grow(tileBox, 1);
-            const Box& xbx = mfi.nodaltilebox(0);
-            const Box& ybx = mfi.nodaltilebox(1);
             const Box& zbx = mfi.nodaltilebox(2);
 
             Array4<const Real> const utilde_arr = utilde[lev].array(mfi);
             Array4<const Real> const ufull_arr = ufull[lev].array(mfi);
-            Array4<Real> const utrans_arr = utrans[lev][0].array(mfi);
-            Array4<Real> const vtrans_arr = utrans[lev][1].array(mfi);
             Array4<Real> const wtrans_arr = utrans[lev][2].array(mfi);
             Array4<Real> const Im_arr = Im.array(mfi);
             Array4<Real> const Ip_arr = Ip.array(mfi);
             Array4<const Real> const w0_arr = w0_cart[lev].array(mfi);
-            Array4<const Real> const w0macx = w0mac[lev][0].array(mfi);
-            Array4<const Real> const w0macy = w0mac[lev][1].array(mfi);
             Array4<const Real> const w0macz = w0mac[lev][2].array(mfi);
 
             // z-direction
@@ -667,9 +641,7 @@ Maestro::MakeUtrans (const Vector<MultiFab>& utilde,
                 }
             });
         } // end MFIter loop
-        
 #endif
-
     } // end loop over levels
 
     if (finest_level == 0) {

--- a/Source/MaestroMakeUtrans.cpp
+++ b/Source/MaestroMakeUtrans.cpp
@@ -184,12 +184,32 @@ Maestro::MakeUtrans (const Vector<MultiFab>& utilde,
                 utrans_arr(i,j,k) = 0.5*(ulx+urx) > 0.0 ? ulx : urx;
                 utrans_arr(i,j,k) = test ? 0.0 : utrans_arr(i,j,k);
             });
+        }
+
+#ifdef _OPENMP
+#pragma omp parallel
+#endif
+        for ( MFIter mfi(utilde_mf, TilingIfNotGPU()); mfi.isValid(); ++mfi ) {
+
+            // Get the index space of the valid region
+            const Box& tileBox = mfi.tilebox();
+            const Box& obx = amrex::grow(tileBox, 1);
+            const Box& xbx = mfi.nodaltilebox(0);
+            const Box& ybx = mfi.nodaltilebox(1);
+
+            Array4<const Real> const utilde_arr = utilde[lev].array(mfi);
+            Array4<const Real> const ufull_arr = ufull[lev].array(mfi);
+            Array4<Real> const utrans_arr = utrans[lev][0].array(mfi);
+            Array4<Real> const vtrans_arr = utrans[lev][1].array(mfi);
+            Array4<Real> const Im_arr = Im.array(mfi);
+            Array4<Real> const Ip_arr = Ip.array(mfi);
+            Array4<const Real> const w0_arr = w0_cart[lev].array(mfi);
 
             if (ppm_type == 0) {
-                // we're going to reuse Im here as slopey as it has the
+                // we're going to reuse Ip here as slopey as it has the
                 // correct number of ghost zones
                 Slopey(obx, v_mf.array(mfi), 
-                       Im_arr, 
+                       Ip_arr, 
                        domainBox, bcs_u, 
                        1,1);
             } else {
@@ -200,9 +220,9 @@ Maestro::MakeUtrans (const Vector<MultiFab>& utilde,
                     false, 1, 1);
            }
 
-           // create vtrans
-            bclo = phys_bc[1];
-            bchi = phys_bc[AMREX_SPACEDIM+1];
+            // create vtrans
+            int bclo = phys_bc[1];
+            int bchi = phys_bc[AMREX_SPACEDIM+1];
 
             AMREX_PARALLEL_FOR_3D(ybx, i, j, k, 
             {
@@ -212,9 +232,9 @@ Maestro::MakeUtrans (const Vector<MultiFab>& utilde,
                 if (ppm_type_local == 0) {
                     // // extrapolate to edges
                     vly = utilde_arr(i,j-1,k,1) 
-                        + (0.5-(dt2/hy)*max(0.0,ufull_arr(i,j-1,k,1)))*Im_arr(i,j-1,k,0);
+                        + (0.5-(dt2/hy)*max(0.0,ufull_arr(i,j-1,k,1)))*Ip_arr(i,j-1,k,0);
                     vry = utilde_arr(i,j  ,k,1) 
-                        - (0.5+(dt2/hy)*min(0.0,ufull_arr(i,j  ,k,1)))*Im_arr(i,j  ,k,0);
+                        - (0.5+(dt2/hy)*min(0.0,ufull_arr(i,j  ,k,1)))*Ip_arr(i,j  ,k,0);
 
                 } else if (ppm_type_local == 1 || ppm_type_local == 2) {
                     // extrapolate to edges
@@ -316,33 +336,6 @@ Maestro::MakeUtrans (const Vector<MultiFab>& utilde,
                     domainBox, bcs_u, dx, 
                     false, 0, 0);
             }
-        }
-
-       
-
-#ifdef _OPENMP
-#pragma omp parallel
-#endif
-        for ( MFIter mfi(utilde_mf, TilingIfNotGPU()); mfi.isValid(); ++mfi ) {
-
-            // Get the index space of the valid region
-            const Box& tileBox = mfi.tilebox();
-            const Box& obx = amrex::grow(tileBox, 1);
-            const Box& xbx = mfi.nodaltilebox(0);
-            const Box& ybx = mfi.nodaltilebox(1);
-            const Box& zbx = mfi.nodaltilebox(2);
-
-            Array4<const Real> const utilde_arr = utilde[lev].array(mfi);
-            Array4<const Real> const ufull_arr = ufull[lev].array(mfi);
-            Array4<Real> const utrans_arr = utrans[lev][0].array(mfi);
-            Array4<Real> const vtrans_arr = utrans[lev][1].array(mfi);
-            Array4<Real> const wtrans_arr = utrans[lev][2].array(mfi);
-            Array4<Real> const Im_arr = Im.array(mfi);
-            Array4<Real> const Ip_arr = Ip.array(mfi);
-            Array4<const Real> const w0_arr = w0_cart[lev].array(mfi);
-            Array4<const Real> const w0macx = w0mac[lev][0].array(mfi);
-            Array4<const Real> const w0macy = w0mac[lev][1].array(mfi);
-            Array4<const Real> const w0macz = w0mac[lev][2].array(mfi); 
             
             // create utrans
             int bclo = phys_bc[0];
@@ -454,10 +447,10 @@ Maestro::MakeUtrans (const Vector<MultiFab>& utilde,
 
             // y-direction
             if (ppm_type == 0) {
-                // we're going to reuse Im here as slopey as it has the
+                // we're going to reuse Ip here as slopey as it has the
                 // correct number of ghost zones
                 Slopey(obx, v_mf.array(mfi), 
-                       Im_arr, 
+                       Ip_arr, 
                        domainBox, bcs_u, 
                        1,1);
             } else {
@@ -467,33 +460,6 @@ Maestro::MakeUtrans (const Vector<MultiFab>& utilde,
                     domainBox, bcs_u, dx, 
                     false, 1, 1);
             }
-        }
-
-        
-
-#ifdef _OPENMP
-#pragma omp parallel
-#endif
-        for ( MFIter mfi(utilde_mf, TilingIfNotGPU()); mfi.isValid(); ++mfi ) {
-
-            // Get the index space of the valid region
-            const Box& tileBox = mfi.tilebox();
-            const Box& obx = amrex::grow(tileBox, 1);
-            const Box& xbx = mfi.nodaltilebox(0);
-            const Box& ybx = mfi.nodaltilebox(1);
-            const Box& zbx = mfi.nodaltilebox(2);
-
-            Array4<const Real> const utilde_arr = utilde[lev].array(mfi);
-            Array4<const Real> const ufull_arr = ufull[lev].array(mfi);
-            Array4<Real> const utrans_arr = utrans[lev][0].array(mfi);
-            Array4<Real> const vtrans_arr = utrans[lev][1].array(mfi);
-            Array4<Real> const wtrans_arr = utrans[lev][2].array(mfi);
-            Array4<Real> const Im_arr = Im.array(mfi);
-            Array4<Real> const Ip_arr = Ip.array(mfi);
-            Array4<const Real> const w0_arr = w0_cart[lev].array(mfi);
-            Array4<const Real> const w0macx = w0mac[lev][0].array(mfi);
-            Array4<const Real> const w0macy = w0mac[lev][1].array(mfi);
-            Array4<const Real> const w0macz = w0mac[lev][2].array(mfi);
 
             // create vtrans
             int bclo = phys_bc[1];
@@ -507,9 +473,9 @@ Maestro::MakeUtrans (const Vector<MultiFab>& utilde,
                 if (ppm_type_local == 0) {
                     // extrapolate to edges
                     vly = utilde_arr(i,j-1,k,1) 
-                        + (0.5-(dt2/hy)*max(0.0,ufull_arr(i,j-1,k,1)))*Im_arr(i,j-1,k,0);
+                        + (0.5-(dt2/hy)*max(0.0,ufull_arr(i,j-1,k,1)))*Ip_arr(i,j-1,k,0);
                     vry = utilde_arr(i,j  ,k,1) 
-                        - (0.5+(dt2/hy)*min(0.0,ufull_arr(i,j  ,k,1)))*Im_arr(i,j  ,k,0);
+                        - (0.5+(dt2/hy)*min(0.0,ufull_arr(i,j  ,k,1)))*Ip_arr(i,j  ,k,0);
 
                 } else if (ppm_type_local == 1 || ppm_type_local == 2) {
                     // extrapolate to edges
@@ -606,10 +572,10 @@ Maestro::MakeUtrans (const Vector<MultiFab>& utilde,
 
             // z-direction
             if (ppm_type == 0) {
-                // we're going to reuse Im here as slopez as it has the
+                // we're going to reuse Ip here as slopez as it has the
                 // correct number of ghost zones
                 Slopez(obx, w_mf.array(mfi), 
-                       Im_arr, 
+                       Ip_arr, 
                        domainBox, bcs_u,  
                        1,2);
             } else {
@@ -619,33 +585,6 @@ Maestro::MakeUtrans (const Vector<MultiFab>& utilde,
                     domainBox, bcs_u, dx, 
                     false, 2, 2);
             }
-        }
-
-        
-
-#ifdef _OPENMP
-#pragma omp parallel
-#endif
-        for ( MFIter mfi(utilde_mf, TilingIfNotGPU()); mfi.isValid(); ++mfi ) {
-
-            // Get the index space of the valid region
-            const Box& tileBox = mfi.tilebox();
-            const Box& obx = amrex::grow(tileBox, 1);
-            const Box& xbx = mfi.nodaltilebox(0);
-            const Box& ybx = mfi.nodaltilebox(1);
-            const Box& zbx = mfi.nodaltilebox(2);
-
-            Array4<const Real> const utilde_arr = utilde[lev].array(mfi);
-            Array4<const Real> const ufull_arr = ufull[lev].array(mfi);
-            Array4<Real> const utrans_arr = utrans[lev][0].array(mfi);
-            Array4<Real> const vtrans_arr = utrans[lev][1].array(mfi);
-            Array4<Real> const wtrans_arr = utrans[lev][2].array(mfi);
-            Array4<Real> const Im_arr = Im.array(mfi);
-            Array4<Real> const Ip_arr = Ip.array(mfi);
-            Array4<const Real> const w0_arr = w0_cart[lev].array(mfi);
-            Array4<const Real> const w0macx = w0mac[lev][0].array(mfi);
-            Array4<const Real> const w0macy = w0mac[lev][1].array(mfi);
-            Array4<const Real> const w0macz = w0mac[lev][2].array(mfi);
 
             // create wtrans
             int bclo = phys_bc[2];
@@ -659,9 +598,9 @@ Maestro::MakeUtrans (const Vector<MultiFab>& utilde,
                 if (ppm_type_local == 0) {
                     // extrapolate to edges
                     wlz = utilde_arr(i,j,k-1,2) 
-                        + (0.5-(dt2/hz)*max(0.0,ufull_arr(i,j,k-1,2)))*Im_arr(i,j,k-1,0);
+                        + (0.5-(dt2/hz)*max(0.0,ufull_arr(i,j,k-1,2)))*Ip_arr(i,j,k-1,0);
                     wrz = utilde_arr(i,j,k  ,2) 
-                        - (0.5+(dt2/hz)*min(0.0,ufull_arr(i,j,k  ,2)))*Im_arr(i,j,k  ,0);
+                        - (0.5+(dt2/hz)*min(0.0,ufull_arr(i,j,k  ,2)))*Ip_arr(i,j,k  ,0);
                 } else if (ppm_type_local == 1 || ppm_type_local == 2) {
                     // extrapolate to edges
                     wlz = Ip_arr(i,j,k-1,2);

--- a/Source/MaestroMakeUtrans.cpp
+++ b/Source/MaestroMakeUtrans.cpp
@@ -75,6 +75,8 @@ Maestro::MakeUtrans (const Vector<MultiFab>& utilde,
 #endif
         }
 
+#if (AMREX_SPACEDIM == 2)
+
 #ifdef _OPENMP
 #pragma omp parallel
 #endif
@@ -85,27 +87,14 @@ Maestro::MakeUtrans (const Vector<MultiFab>& utilde,
             const Box& obx = amrex::grow(tileBox, 1);
             const Box& xbx = mfi.nodaltilebox(0);
             const Box& ybx = mfi.nodaltilebox(1);
-#if (AMREX_SPACEDIM == 3)
-            const Box& zbx = mfi.nodaltilebox(2);
-#endif
 
             Array4<const Real> const utilde_arr = utilde[lev].array(mfi);
             Array4<const Real> const ufull_arr = ufull[lev].array(mfi);
             Array4<Real> const utrans_arr = utrans[lev][0].array(mfi);
             Array4<Real> const vtrans_arr = utrans[lev][1].array(mfi);
-#if (AMREX_SPACEDIM == 3)
-            Array4<Real> const wtrans_arr = utrans[lev][2].array(mfi);
-#endif
             Array4<Real> const Im_arr = Im.array(mfi);
             Array4<Real> const Ip_arr = Ip.array(mfi);
             Array4<const Real> const w0_arr = w0_cart[lev].array(mfi);
-#if (AMREX_SPACEDIM == 3)
-            Array4<const Real> const w0macx = w0mac[lev][0].array(mfi);
-            Array4<const Real> const w0macy = w0mac[lev][1].array(mfi);
-            Array4<const Real> const w0macz = w0mac[lev][2].array(mfi);
-#endif
-
-#if (AMREX_SPACEDIM == 2)
 
             if (ppm_type == 0) {
                 // we're going to reuse Ip here as slopex as it has the
@@ -284,8 +273,33 @@ Maestro::MakeUtrans (const Vector<MultiFab>& utilde,
                     vly : vry;
                 vtrans_arr(i,j,k) = test ? 0.0 : vtrans_arr(i,j,k);
             });
-
+        } // end MFIter loop
+        
 #elif (AMREX_SPACEDIM == 3)
+
+#ifdef _OPENMP
+#pragma omp parallel
+#endif
+        for ( MFIter mfi(utilde_mf, TilingIfNotGPU()); mfi.isValid(); ++mfi ) {
+
+            // Get the index space of the valid region
+            const Box& tileBox = mfi.tilebox();
+            const Box& obx = amrex::grow(tileBox, 1);
+            const Box& xbx = mfi.nodaltilebox(0);
+            const Box& ybx = mfi.nodaltilebox(1);
+            const Box& zbx = mfi.nodaltilebox(2);
+
+            Array4<const Real> const utilde_arr = utilde[lev].array(mfi);
+            Array4<const Real> const ufull_arr = ufull[lev].array(mfi);
+            Array4<Real> const utrans_arr = utrans[lev][0].array(mfi);
+            Array4<Real> const vtrans_arr = utrans[lev][1].array(mfi);
+            Array4<Real> const wtrans_arr = utrans[lev][2].array(mfi);
+            Array4<Real> const Im_arr = Im.array(mfi);
+            Array4<Real> const Ip_arr = Ip.array(mfi);
+            Array4<const Real> const w0_arr = w0_cart[lev].array(mfi);
+            Array4<const Real> const w0macx = w0mac[lev][0].array(mfi);
+            Array4<const Real> const w0macy = w0mac[lev][1].array(mfi);
+            Array4<const Real> const w0macz = w0mac[lev][2].array(mfi);
 
             // x-direction
             if (ppm_type == 0) {
@@ -302,7 +316,34 @@ Maestro::MakeUtrans (const Vector<MultiFab>& utilde,
                     domainBox, bcs_u, dx, 
                     false, 0, 0);
             }
+        }
 
+       
+
+#ifdef _OPENMP
+#pragma omp parallel
+#endif
+        for ( MFIter mfi(utilde_mf, TilingIfNotGPU()); mfi.isValid(); ++mfi ) {
+
+            // Get the index space of the valid region
+            const Box& tileBox = mfi.tilebox();
+            const Box& obx = amrex::grow(tileBox, 1);
+            const Box& xbx = mfi.nodaltilebox(0);
+            const Box& ybx = mfi.nodaltilebox(1);
+            const Box& zbx = mfi.nodaltilebox(2);
+
+            Array4<const Real> const utilde_arr = utilde[lev].array(mfi);
+            Array4<const Real> const ufull_arr = ufull[lev].array(mfi);
+            Array4<Real> const utrans_arr = utrans[lev][0].array(mfi);
+            Array4<Real> const vtrans_arr = utrans[lev][1].array(mfi);
+            Array4<Real> const wtrans_arr = utrans[lev][2].array(mfi);
+            Array4<Real> const Im_arr = Im.array(mfi);
+            Array4<Real> const Ip_arr = Ip.array(mfi);
+            Array4<const Real> const w0_arr = w0_cart[lev].array(mfi);
+            Array4<const Real> const w0macx = w0mac[lev][0].array(mfi);
+            Array4<const Real> const w0macy = w0mac[lev][1].array(mfi);
+            Array4<const Real> const w0macz = w0mac[lev][2].array(mfi); 
+            
             // create utrans
             int bclo = phys_bc[0];
             int bchi = phys_bc[AMREX_SPACEDIM];
@@ -383,6 +424,33 @@ Maestro::MakeUtrans (const Vector<MultiFab>& utilde,
                     utrans_arr(i,j,k) = test ? 0.0 : utrans_arr(i,j,k);
                 }
             });
+        }
+
+        
+
+#ifdef _OPENMP
+#pragma omp parallel
+#endif
+        for ( MFIter mfi(utilde_mf, TilingIfNotGPU()); mfi.isValid(); ++mfi ) {
+
+            // Get the index space of the valid region
+            const Box& tileBox = mfi.tilebox();
+            const Box& obx = amrex::grow(tileBox, 1);
+            const Box& xbx = mfi.nodaltilebox(0);
+            const Box& ybx = mfi.nodaltilebox(1);
+            const Box& zbx = mfi.nodaltilebox(2);
+
+            Array4<const Real> const utilde_arr = utilde[lev].array(mfi);
+            Array4<const Real> const ufull_arr = ufull[lev].array(mfi);
+            Array4<Real> const utrans_arr = utrans[lev][0].array(mfi);
+            Array4<Real> const vtrans_arr = utrans[lev][1].array(mfi);
+            Array4<Real> const wtrans_arr = utrans[lev][2].array(mfi);
+            Array4<Real> const Im_arr = Im.array(mfi);
+            Array4<Real> const Ip_arr = Ip.array(mfi);
+            Array4<const Real> const w0_arr = w0_cart[lev].array(mfi);
+            Array4<const Real> const w0macx = w0mac[lev][0].array(mfi);
+            Array4<const Real> const w0macy = w0mac[lev][1].array(mfi);
+            Array4<const Real> const w0macz = w0mac[lev][2].array(mfi);
 
             // y-direction
             if (ppm_type == 0) {
@@ -399,10 +467,37 @@ Maestro::MakeUtrans (const Vector<MultiFab>& utilde,
                     domainBox, bcs_u, dx, 
                     false, 1, 1);
             }
+        }
+
+        
+
+#ifdef _OPENMP
+#pragma omp parallel
+#endif
+        for ( MFIter mfi(utilde_mf, TilingIfNotGPU()); mfi.isValid(); ++mfi ) {
+
+            // Get the index space of the valid region
+            const Box& tileBox = mfi.tilebox();
+            const Box& obx = amrex::grow(tileBox, 1);
+            const Box& xbx = mfi.nodaltilebox(0);
+            const Box& ybx = mfi.nodaltilebox(1);
+            const Box& zbx = mfi.nodaltilebox(2);
+
+            Array4<const Real> const utilde_arr = utilde[lev].array(mfi);
+            Array4<const Real> const ufull_arr = ufull[lev].array(mfi);
+            Array4<Real> const utrans_arr = utrans[lev][0].array(mfi);
+            Array4<Real> const vtrans_arr = utrans[lev][1].array(mfi);
+            Array4<Real> const wtrans_arr = utrans[lev][2].array(mfi);
+            Array4<Real> const Im_arr = Im.array(mfi);
+            Array4<Real> const Ip_arr = Ip.array(mfi);
+            Array4<const Real> const w0_arr = w0_cart[lev].array(mfi);
+            Array4<const Real> const w0macx = w0mac[lev][0].array(mfi);
+            Array4<const Real> const w0macy = w0mac[lev][1].array(mfi);
+            Array4<const Real> const w0macz = w0mac[lev][2].array(mfi);
 
             // create vtrans
-            bclo = phys_bc[1];
-            bchi = phys_bc[AMREX_SPACEDIM+1];
+            int bclo = phys_bc[1];
+            int bchi = phys_bc[AMREX_SPACEDIM+1];
 
             AMREX_PARALLEL_FOR_3D(ybx, i, j, k, 
             {
@@ -481,6 +576,33 @@ Maestro::MakeUtrans (const Vector<MultiFab>& utilde,
                     vtrans_arr(i,j,k) = test ? 0.0 : vtrans_arr(i,j,k);
                 }
             });
+        }
+
+        
+
+#ifdef _OPENMP
+#pragma omp parallel
+#endif
+        for ( MFIter mfi(utilde_mf, TilingIfNotGPU()); mfi.isValid(); ++mfi ) {
+
+            // Get the index space of the valid region
+            const Box& tileBox = mfi.tilebox();
+            const Box& obx = amrex::grow(tileBox, 1);
+            const Box& xbx = mfi.nodaltilebox(0);
+            const Box& ybx = mfi.nodaltilebox(1);
+            const Box& zbx = mfi.nodaltilebox(2);
+
+            Array4<const Real> const utilde_arr = utilde[lev].array(mfi);
+            Array4<const Real> const ufull_arr = ufull[lev].array(mfi);
+            Array4<Real> const utrans_arr = utrans[lev][0].array(mfi);
+            Array4<Real> const vtrans_arr = utrans[lev][1].array(mfi);
+            Array4<Real> const wtrans_arr = utrans[lev][2].array(mfi);
+            Array4<Real> const Im_arr = Im.array(mfi);
+            Array4<Real> const Ip_arr = Ip.array(mfi);
+            Array4<const Real> const w0_arr = w0_cart[lev].array(mfi);
+            Array4<const Real> const w0macx = w0mac[lev][0].array(mfi);
+            Array4<const Real> const w0macy = w0mac[lev][1].array(mfi);
+            Array4<const Real> const w0macz = w0mac[lev][2].array(mfi);
 
             // z-direction
             if (ppm_type == 0) {
@@ -497,10 +619,37 @@ Maestro::MakeUtrans (const Vector<MultiFab>& utilde,
                     domainBox, bcs_u, dx, 
                     false, 2, 2);
             }
+        }
+
+        
+
+#ifdef _OPENMP
+#pragma omp parallel
+#endif
+        for ( MFIter mfi(utilde_mf, TilingIfNotGPU()); mfi.isValid(); ++mfi ) {
+
+            // Get the index space of the valid region
+            const Box& tileBox = mfi.tilebox();
+            const Box& obx = amrex::grow(tileBox, 1);
+            const Box& xbx = mfi.nodaltilebox(0);
+            const Box& ybx = mfi.nodaltilebox(1);
+            const Box& zbx = mfi.nodaltilebox(2);
+
+            Array4<const Real> const utilde_arr = utilde[lev].array(mfi);
+            Array4<const Real> const ufull_arr = ufull[lev].array(mfi);
+            Array4<Real> const utrans_arr = utrans[lev][0].array(mfi);
+            Array4<Real> const vtrans_arr = utrans[lev][1].array(mfi);
+            Array4<Real> const wtrans_arr = utrans[lev][2].array(mfi);
+            Array4<Real> const Im_arr = Im.array(mfi);
+            Array4<Real> const Ip_arr = Ip.array(mfi);
+            Array4<const Real> const w0_arr = w0_cart[lev].array(mfi);
+            Array4<const Real> const w0macx = w0mac[lev][0].array(mfi);
+            Array4<const Real> const w0macy = w0mac[lev][1].array(mfi);
+            Array4<const Real> const w0macz = w0mac[lev][2].array(mfi);
 
             // create wtrans
-            bclo = phys_bc[2];
-            bchi = phys_bc[AMREX_SPACEDIM+2];
+            int bclo = phys_bc[2];
+            int bchi = phys_bc[AMREX_SPACEDIM+2];
 
             AMREX_PARALLEL_FOR_3D(zbx, i, j, k, 
             {
@@ -578,8 +727,10 @@ Maestro::MakeUtrans (const Vector<MultiFab>& utilde,
                     wtrans_arr(i,j,k) = test ? 0.0 : wtrans_arr(i,j,k);
                 }
             });
-#endif
         } // end MFIter loop
+        
+#endif
+
     } // end loop over levels
 
     if (finest_level == 0) {

--- a/Source/MaestroPlot.cpp
+++ b/Source/MaestroPlot.cpp
@@ -520,10 +520,7 @@ Maestro::PlotFileMF (const int nPlot,
             // we have to use protected_divide here to guard against division by zero
             // in the case that there are zeros rho0
             MultiFab& plot_mf_data_mf = *plot_mf_data[i];
-#ifdef _OPENMP
-#pragma omp parallel
-#endif
-            for ( MFIter mfi(plot_mf_data_mf, TilingIfNotGPU()); mfi.isValid(); ++mfi ) {
+            for ( MFIter mfi(plot_mf_data_mf); mfi.isValid(); ++mfi ) {
                 plot_mf_data_mf[mfi].protected_divide(plot_mf_data_mf[mfi], dest_comp, dest_comp+2);
             }
 


### PR DESCRIPTION
This fixes #149.  I had to:
Split up the dimensionality of MaestroMakeUtrans so avoid race conditions in writing to temporaries
Fix a nodal tile box issue in MakeRhoXFlux
Disable tiling/GPU of computation of rho0 in MaestroPlot.cpp
Test this with reacting_bubble/inputs_3d_amr_regression and inputs_2d_amr_regression with multiple MPIs and multiple OMPs before merging