### PR TITLE
put autogenerated source files in their own subdirectory

### DIFF
--- a/Exec/Make.Maestro
+++ b/Exec/Make.Maestro
@@ -28,6 +28,8 @@ endif
 
 include $(AMREX_HOME)/Tools/GNUMake/Make.defs
 
+MAESTROEX_AUTO_SOURCE_DIR := $(TmpBuildDir)/maestroex_sources/$(optionsSuffix).EXE
+
 all: $(executable)
 	@echo SUCCESS
 
@@ -136,6 +138,11 @@ ifndef GENERAL_NET_INPUTS
    endif
 endif
 
+# Specify that we want to write the general_null network
+# files to our temporary build directory (this has no
+# effect for other networks).
+NETWORK_OUTPUT_PATH = $(MAESTROEX_AUTO_SOURCE_DIR)
+
 EXTERN_CORE += $(EOS_HOME)
 EXTERN_CORE += $(EOS_PATH)
 
@@ -173,6 +180,11 @@ EXTERN_CORE += $(TOP)/Microphysics/conductivity
 EXTERN_CORE += $(COND_HOME)
 EXTERN_CORE += $(COND_PATH)
 
+# for the automatically generated network_properties stuff, we should
+# tell it where to put them
+NETWORK_HEADERS_DIR = $(MAESTROEX_AUTO_SOURCE_DIR)
+
+
 Bpack += $(foreach dir, $(EXTERN_CORE), $(dir)/Make.package)
 Blocs += $(foreach dir, $(EXTERN_CORE), $(dir))
 
@@ -193,6 +205,14 @@ VPATH_LOCATIONS   += $(Blocs)
 #include $(AMREX_HOME)/Src/LinearSolvers/C_to_F_MG/Make.package
 #include $(AMREX_HOME)/Src/LinearSolvers/F_MG/FParallelMG.mak
 #include $(AMREX_HOME)/Src/F_BaseLib/FParallelMG.mak
+
+
+#------------------------------------------------------------------------------
+# make generated source files location
+#------------------------------------------------------------------------------
+VPATH_LOCATIONS += $(MAESTROEX_AUTO_SOURCE_DIR)
+INCLUDE_LOCATIONS += $(MAESTROEX_AUTO_SOURCE_DIR)
+
 
 #------------------------------------------------------------------------------
 # runtime parameters
@@ -221,12 +241,14 @@ ifdef USE_CUDA
   endif
 endif
 
-extern.F90: $(PROBIN_PARAMETERS) $(PROBIN_TEMPLATE)
+$(MAESTROEX_AUTO_SOURCE_DIR)/extern.F90: $(PROBIN_PARAMETERS) $(PROBIN_TEMPLATE)
+	@if [ ! -d $(MAESTROEX_AUTO_SOURCE_DIR) ]; then mkdir -p $(MAESTROEX_AUTO_SOURCE_DIR); fi
 	@echo " "
 	@echo "${bold}WRITING extern.F90${normal}"
 	$(AMREX_HOME)/Tools/F_scripts/write_probin.py \
-          -t $(PROBIN_TEMPLATE) -o extern.F90 -n probin \
-          --pa "$(PROBIN_PARAMETERS) $(EXTERN_PARAMETERS)" $(MANAGED_PROBIN_FLAG)
+          -t $(PROBIN_TEMPLATE) -o $(MAESTROEX_AUTO_SOURCE_DIR)/extern.F90 -n probin \
+          --pa "$(PROBIN_PARAMETERS) $(EXTERN_PARAMETERS)" $(MANAGED_PROBIN_FLAG) \
+          --cxx_prefix $(MAESTROEX_AUTO_SOURCE_DIR)/extern
 	@echo " "
 
 
@@ -288,10 +310,9 @@ endif
 endif
 
 clean::
-
 	$(SILENT) $(RM) extern.F90 extern.f90
-
 	$(SILENT) $(RM) AMReX_buildInfo.cpp
+	$(SILENT) $(RM) $(MAESTROEX_AUTO_SOURCE_DIR)/*.H $(MAESTROEX_AUTO_SOURCE_DIR)/*.[fF]90
 
 clean::
 	@if [ -L helm_table.dat ]; then rm -f helm_table.dat; fi


### PR DESCRIPTION
This follows the approach of Castro and puts all of the autogenerated source files in their own directory, tmp_build_dir/maestroex_source_files/.  This makes it easier to clean things up.