### PR TITLE
Hardcode a max level and abort if exceeded

### DIFF
--- a/Source/Maestro.H
+++ b/Source/Maestro.H
@@ -26,6 +26,9 @@ typedef amrex::Vector< amrex::Real > RealVector;
 typedef amrex::Vector< int > IntVector;
 #endif
 
+/// hard code a maximum level limit
+#define MAESTRO_MAX_LEVELS 15
+
 class Maestro
     : public amrex::AmrCore
 {

--- a/Source/MaestroSetup.cpp
+++ b/Source/MaestroSetup.cpp
@@ -46,6 +46,9 @@ Maestro::Setup ()
 
     maestro_conductivity_init();
 
+    // check max level does not exceed hardcoded limit 
+    if (max_level > MAESTRO_MAX_LEVELS) Abort("max_level exceeds MAESTROeX's limit!");
+
     const Real* probLo = geom[0].ProbLo();
     const Real* probHi = geom[0].ProbHi();
 

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -20,60 +20,60 @@ int main(int argc, char* argv[])
         }
     }
 
-        // in AMReX.cpp
-        Initialize(argc,argv);
+    // in AMReX.cpp
+    Initialize(argc,argv);
 
-        // Refuse to continue if we did not provide an inputs file.
+    // Refuse to continue if we did not provide an inputs file.
 
-        if (argc <= 1) {
-                Abort("Error: no inputs file provided on command line.");
-        }
+    if (argc <= 1) {
+        Abort("Error: no inputs file provided on command line.");
+    }
 
-        // Save the inputs file name for later.
+    // Save the inputs file name for later.
 
-        if (!strchr(argv[1], '=')) {
-                inputs_name = argv[1];
-        }
+    if (!strchr(argv[1], '=')) {
+        inputs_name = argv[1];
+    }
 
-        // timer for profiling
-        BL_PROFILE_VAR("main()", main);
+    // timer for profiling
+    BL_PROFILE_VAR("main()", main);
+
+    // wallclock time
+    const Real strt_total = ParallelDescriptor::second();
+
+    {
+        // declare an Maestro object to manage multilevel data
+        Maestro maestro;
+
+        // read in C++/F90 parameters
+        // define global C++/F90 variables and initialize network
+        // set up boundary conditions
+        // initialize base state geometry parameters
+        // set istep, t_new, t_old
+        // allocate MultiFabs and base state arrays
+        maestro.Setup();
+
+        // initialize multifab and base state data
+        // perform initial projection
+        // perform divu iters
+        // perform initial (pressure) iterations
+        maestro.Init();
+
+        // advance solution to final time
+        maestro.Evolve();
 
         // wallclock time
-        const Real strt_total = ParallelDescriptor::second();
+        Real end_total = ParallelDescriptor::second() - strt_total;
 
-        {
-                // declare an Maestro object to manage multilevel data
-                Maestro maestro;
-
-                // read in C++/F90 parameters
-                // define global C++/F90 variables and initialize network
-                // set up boundary conditions
-                // initialize base state geometry parameters
-                // set istep, t_new, t_old
-                // allocate MultiFabs and base state arrays
-                maestro.Setup();
-
-                // initialize multifab and base state data
-                // perform initial projection
-                // perform divu iters
-                // perform initial (pressure) iterations
-                maestro.Init();
-
-                // advance solution to final time
-                maestro.Evolve();
-
-                // wallclock time
-                Real end_total = ParallelDescriptor::second() - strt_total;
-
-                // print wallclock time
-                ParallelDescriptor::ReduceRealMax(end_total,ParallelDescriptor::IOProcessorNumber());
-                Print() << "\nTotal Time: " << end_total << '\n';
-        }
+        // print wallclock time
+        ParallelDescriptor::ReduceRealMax(end_total,ParallelDescriptor::IOProcessorNumber());
+        Print() << "\nTotal Time: " << end_total << '\n';
+    }
 
 
-        // destroy timer for profiling
-        BL_PROFILE_VAR_STOP(main);
+    // destroy timer for profiling
+    BL_PROFILE_VAR_STOP(main);
 
-        // in AMReX.cpp
-        Finalize();
+    // in AMReX.cpp
+    Finalize();
 }


### PR DESCRIPTION
This hardcodes a maximum level and will cause the code to abort before it tries to do set up any grids if that level is exceeded. 

This is needed to define some C arrays within C++ lambda regions (as they require the size to be known at compile time). 