### PR TITLE
Makew0 should be called on w0 instead of w0_old

### DIFF
--- a/Source/MaestroAdvance.cpp
+++ b/Source/MaestroAdvance.cpp
@@ -307,7 +307,7 @@ Maestro::AdvanceTimeStep (bool is_initIter) {
 
         // compute w0, w0_force, and delta_chi_w0
         is_predictor = 1;
-        Makew0(w0_old, w0_force, Sbar, rho0_old, rho0_old, 
+        Makew0(w0, w0_force, Sbar, rho0_old, rho0_old, 
                p0_old, p0_old, gamma1bar_old, gamma1bar_old, 
                p0_minus_peosbar, delta_chi_w0, dt, dtold, is_predictor);
 
@@ -707,7 +707,7 @@ Maestro::AdvanceTimeStep (bool is_initIter) {
 
         // compute w0, w0_force, and delta_chi_w0
         is_predictor = 0;
-        Makew0(w0_old, w0_force, Sbar, rho0_old, rho0_new, 
+        Makew0(w0, w0_force, Sbar, rho0_old, rho0_new, 
                 p0_old, p0_new, gamma1bar_old, gamma1bar_new, 
                 p0_minus_peosbar, delta_chi_w0, dt, dtold, is_predictor);
 

--- a/Source/MaestroAdvanceAvg.cpp
+++ b/Source/MaestroAdvanceAvg.cpp
@@ -293,7 +293,7 @@ Maestro::AdvanceTimeStepAverage (bool is_initIter) {
 
             // compute w0, w0_force, and delta_chi_w0
             is_predictor = 1;
-            Makew0(w0_old, w0_force_dummy, Sbar, rho0_old, rho0_old, 
+            Makew0(w0, w0_force_dummy, Sbar, rho0_old, rho0_old, 
                    p0_old, p0_old, gamma1bar_old, gamma1bar_old, 
                    p0_minus_peosbar, delta_chi_w0_dummy, dt, dtold, 
                    is_predictor);
@@ -615,7 +615,7 @@ Maestro::AdvanceTimeStepAverage (bool is_initIter) {
 
             // compute w0, w0_force, and delta_chi_w0
             is_predictor = 0;
-            Makew0(w0_old, w0_force_dummy, Sbar, rho0_old, rho0_old, 
+            Makew0(w0, w0_force_dummy, Sbar, rho0_old, rho0_old, 
                    p0_old, p0_old, gamma1bar_old, gamma1bar_old, 
                    p0_minus_peosbar, delta_chi_w0_dummy, dt, dtold, 
                    is_predictor);
@@ -854,7 +854,7 @@ Maestro::AdvanceTimeStepAverage (bool is_initIter) {
 
             // compute w0, w0_force, and delta_chi_w0
             is_predictor = 0;
-            Makew0(w0_old, w0_force_dummy, Sbar, rho0_new, rho0_new, 
+            Makew0(w0, w0_force_dummy, Sbar, rho0_new, rho0_new, 
                     p0_new, p0_new, gamma1bar_new, gamma1bar_new, 
                     p0_minus_peosbar, delta_chi_w0_dummy, dt, dtold, 
                     is_predictor);

--- a/Source/MaestroAdvanceIrreg.cpp
+++ b/Source/MaestroAdvanceIrreg.cpp
@@ -288,7 +288,7 @@ Maestro::AdvanceTimeStepIrreg (bool is_initIter) {
 
         // compute w0, w0_force, and delta_chi_w0
         is_predictor = 1;
-        Makew0(w0_old, w0_force_dummy, Sbar, rho0_old, rho0_old, 
+        Makew0(w0, w0_force_dummy, Sbar, rho0_old, rho0_old, 
                p0_old, p0_old, gamma1bar_old, gamma1bar_old, 
                p0_minus_peosbar, delta_chi_w0_dummy, dt, dtold, is_predictor);
 
@@ -603,7 +603,7 @@ Maestro::AdvanceTimeStepIrreg (bool is_initIter) {
 
         // compute w0, w0_force, and delta_chi_w0
         is_predictor = 0;
-        Makew0(w0_old, w0_force_dummy, Sbar, rho0_old, rho0_new, 
+        Makew0(w0, w0_force_dummy, Sbar, rho0_old, rho0_new, 
                p0_old, p0_new, gamma1bar_old, gamma1bar_new, 
                p0_minus_peosbar, delta_chi_w0_dummy, dt, dtold, is_predictor);
 
@@ -829,7 +829,7 @@ Maestro::AdvanceTimeStepIrreg (bool is_initIter) {
 
         // compute w0, w0_force, and delta_chi_w0
         is_predictor = 0;
-        Makew0(w0_old, w0_force_dummy, Sbar, rho0_new, rho0_new, 
+        Makew0(w0, w0_force_dummy, Sbar, rho0_new, rho0_new, 
                p0_new, p0_new, gamma1bar_new, gamma1bar_new, 
                p0_minus_peosbar, delta_chi_w0_dummy, dt, dtold, is_predictor);
 

--- a/Source/MaestroAdvanceSdc.cpp
+++ b/Source/MaestroAdvanceSdc.cpp
@@ -302,7 +302,7 @@ Maestro::AdvanceTimeStepSDC (bool is_initIter) {
 
             // compute w0, w0_force, and delta_chi_w0
             is_predictor = 1;
-            Makew0(w0_old, w0_force_dummy, Sbar, rho0_old, 
+            Makew0(w0, w0_force_dummy, Sbar, rho0_old, 
                    rho0_old, p0_old, p0_old, gamma1bar_old, 
                    gamma1bar_old, p0_minus_peosbar, 
                    delta_chi_w0_dummy, dt, dtold, is_predictor);
@@ -764,7 +764,7 @@ Maestro::AdvanceTimeStepSDC (bool is_initIter) {
                     
                     // compute w0, w0_force, and delta_chi_w0
                     is_predictor = 0;
-                    Makew0(w0_old, w0_force_dummy, Sbar, rho0_old, 
+                    Makew0(w0, w0_force_dummy, Sbar, rho0_old, 
                            rho0_new, p0_old, p0_new, gamma1bar_old, 
                            gamma1bar_new, p0_minus_peosbar, 
                            delta_chi_w0_dummy, dt, dtold, is_predictor);
@@ -1149,7 +1149,7 @@ Maestro::AdvanceTimeStepSDC (bool is_initIter) {
 
             // compute w0, w0_force, and delta_chi_w0
             is_predictor = 0;
-            Makew0(w0_old, w0_force_dummy, Sbar, rho0_new, 
+            Makew0(w0, w0_force_dummy, Sbar, rho0_new, 
                    rho0_new, p0_new, p0_new, gamma1bar_new, 
                    gamma1bar_new, p0_minus_peosbar, 
                    delta_chi_w0_dummy, dt, dtold, is_predictor);


### PR DESCRIPTION
Currently in the `Advance` routines `Makew0` is called on `w0_old`. This variable is local to `Advance`, and so it means that all routines during the timestep that use `w0` are in affect using a lagged value (as `w0_old` is only copied over to `w0` at the end of the timestep). 

This change looks like it modifies the output