### PR TITLE
BaseStateArray struct

### DIFF
--- a/Exec/unit_tests/test_new_basestate/main.cpp
+++ b/Exec/unit_tests/test_new_basestate/main.cpp
@@ -30,7 +30,7 @@ int main(int argc, char* argv[])
 
         base_state.setVal(1.0);
 
-        Print() << "print an element: " << base_state(0,0) << std::endl;
+        Print() << "print an element: " << base_state.array()(0,0) << std::endl;
 
         Print() << "defining another base state" << std::endl;
 
@@ -52,7 +52,7 @@ int main(int argc, char* argv[])
 
         deep_copy.setVal(1, 0.0);
 
-        Print() << "print an element: " << deep_copy(0,0,1) << std::endl;
+        Print() << "print an element: " << deep_copy.array()(0,0,1) << std::endl;
 
         Print() << "are the two base states equal? " << (base_state == deep_copy) << std::endl;
 
@@ -62,21 +62,28 @@ int main(int argc, char* argv[])
 
         BaseState<Real> c_base(f_base, nlevs, len, ncomp);
 
-        Print() << "let's iterate over the base state" << std::endl;
+        Print() << "let's iterate over the base state using a BaseStateArray" << std::endl;
+        BaseStateArray<Real> base_arr = base_state.array();
         for (auto l = 0; l < nlevs; ++l) {
-            AMREX_PARALLEL_FOR_1D(base_state.length(), n, {
-                base_state(l,n) = 0.5;
+            AMREX_PARALLEL_FOR_1D(len, n, {
+                base_arr(l,n) = 0.5;
             });
         }
+        Gpu::synchronize();
+
+        Print() << "base_state = " << base_arr(0,0) << std::endl;
 
         Print() << "we can also iterate over the components" << std::endl;
         for (auto l = 0; l < nlevs; ++l) {
-            AMREX_PARALLEL_FOR_1D(base_state.length(), n, {
-                for (auto comp = 0; comp < base_state.nComp(); ++comp) {
-                    base_state(l,n,comp) = Real(comp);
+            AMREX_PARALLEL_FOR_1D(len, n, {
+                for (auto comp = 0; comp < ncomp; ++comp) {
+                    base_arr(l,n,comp) = Real(comp);
                 }
             });
         }
+        Gpu::synchronize();
+
+        Print() << "base_state = " << base_arr(0,0,0) << std::endl;
 
         Print() << "multiply by scalar" << std::endl;
 

--- a/Source/BaseState.H
+++ b/Source/BaseState.H
@@ -17,6 +17,7 @@ struct BaseStateArray
     int len;
     int nvar;
 
+    /// default constructor
     AMREX_GPU_HOST_DEVICE
     constexpr BaseStateArray () noexcept 
         : dptr(nullptr), nlev(0), len(0), nvar(0) {}
@@ -27,6 +28,7 @@ struct BaseStateArray
         : dptr(rhs.dptr), nlev(rhs.nlev), len(rhs.len), nvar(rhs.nvar) 
         {}
 
+    /// initialize from pointer 
     AMREX_GPU_HOST_DEVICE
     constexpr BaseStateArray(T* ptr, const int num_levs=1, const int length=1, const int ncomp=1) noexcept
         : dptr(ptr), nlev(num_levs), len(length), nvar(ncomp)
@@ -35,6 +37,7 @@ struct BaseStateArray
     AMREX_GPU_HOST_DEVICE
     explicit operator bool() const noexcept { return dptr != nullptr; }
 
+    /// access elements. If only 2 arguments are passed in, component is set to 0
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     T& operator() (const int lev, const int i, const int n=0) const noexcept {
         AMREX_ASSERT(lev >= 0);
@@ -44,6 +47,7 @@ struct BaseStateArray
         return dptr[(lev*len + i)*nvar + n];
     }
 
+    /// if access using only one index, then this ignores the underlying data structure. Useful for e.g. applying the same operation to all data.
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     T& operator() (const int i) const noexcept {
         return dptr[i];
@@ -75,13 +79,16 @@ struct BaseStateArray
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE 
     int nLevels() const noexcept { return nlev; }
 
+    /// number of cells in base
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     int length() const noexcept { return len; }
 
+    /// number of componenets
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     int nComp() const noexcept { return nvar; }
 };
 
+/// create a BaseStateArray
 template <typename T>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 BaseStateArray<T>
@@ -111,15 +118,16 @@ public:
     /// copy constructor. This makes a deep copy of the src.
     BaseState(const BaseState<T>& src);
 
-    // /// destructor
-    // ~BaseState () { };
-
+    /// return a BaseStateArray object to allow for accessing 
+    /// the underlying data
     AMREX_FORCE_INLINE
     BaseStateArray<T const> array () const noexcept 
     {
         return makeBaseStateArray<T const>(base_data.dataPtr(), nlev, len, nvar);
     } 
 
+    /// return a BaseStateArray object to allow for accessing 
+    /// the underlying data
     AMREX_FORCE_INLINE
     BaseStateArray<T> array () noexcept 
     {
@@ -139,9 +147,11 @@ public:
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE 
     int nLevels() const { return nlev; };
 
+    /// number of cells in base
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     int length() const { return len; };
 
+    /// number of components
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     int nComp() const { return nvar; };
 

--- a/Source/BaseState.H
+++ b/Source/BaseState.H
@@ -8,6 +8,88 @@
 #include <AMReX_AmrCore.H>
 #include <AMReX_MultiFab.H>
 
+template <typename T>
+struct BaseStateArray
+{
+    T* AMREX_RESTRICT dptr;
+
+    int nlev;
+    int len;
+    int nvar;
+
+    AMREX_GPU_HOST_DEVICE
+    constexpr BaseStateArray () noexcept 
+        : dptr(nullptr), nlev(0), len(0), nvar(0) {}
+
+    /// copy constructor
+    AMREX_GPU_HOST_DEVICE
+    constexpr BaseStateArray(BaseStateArray<T> const& rhs) noexcept 
+        : dptr(rhs.dptr), nlev(rhs.nlev), len(rhs.len), nvar(rhs.nvar) 
+        {}
+
+    AMREX_GPU_HOST_DEVICE
+    constexpr BaseStateArray(T* ptr, const int num_levs=1, const int length=1, const int ncomp=1) noexcept
+        : dptr(ptr), nlev(num_levs), len(length), nvar(ncomp)
+        {}
+
+    AMREX_GPU_HOST_DEVICE
+    explicit operator bool() const noexcept { return dptr != nullptr; }
+
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    T& operator() (const int lev, const int i, const int n=0) const noexcept {
+        AMREX_ASSERT(lev >= 0);
+        AMREX_ASSERT((i < this->len && i >= 0) || (lev == 0 && i < nlev*len));
+        AMREX_ASSERT(n < this->nvar && n >= 0);
+
+        return dptr[(lev*len + i)*nvar + n];
+    }
+
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    T& operator() (const int i) const noexcept {
+        return dptr[i];
+    }
+
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    T& operator[] (int i) noexcept {
+        AMREX_ASSERT(i >= 0 && i < nlev*len*nvar);
+
+        return dptr[i];
+    }
+
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    const T& operator[] (const int i) const noexcept {
+        AMREX_ASSERT(i >= 0 && i < nlev*len*nvar);
+
+        return dptr[i];
+    }
+
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    T* ptr (int lev, int i=0, int n=0) const noexcept {
+        return dptr + (lev*len + i)*nvar + n;
+    }
+
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    T* dataPtr () const noexcept { return this->dptr; } 
+
+    /// number of levels in base 
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE 
+    int nLevels() const noexcept { return nlev; }
+
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    int length() const noexcept { return len; }
+
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    int nComp() const noexcept { return nvar; }
+};
+
+template <typename T>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+BaseStateArray<T>
+makeBaseStateArray (T* dptr, const int num_levs=1, const int length=1, const int ncomp=1) noexcept 
+{
+    return BaseStateArray<T>{dptr, num_levs, length, ncomp};
+}
+
 template <class T>
 class BaseState
 {
@@ -32,6 +114,18 @@ public:
     // /// destructor
     // ~BaseState () { };
 
+    AMREX_FORCE_INLINE
+    BaseStateArray<T const> array () const noexcept 
+    {
+        return makeBaseStateArray<T const>(base_data.dataPtr(), nlev, len, nvar);
+    } 
+
+    AMREX_FORCE_INLINE
+    BaseStateArray<T> array () noexcept 
+    {
+        return makeBaseStateArray<T>(base_data.dataPtr(), nlev, len, nvar);
+    } 
+
     /// allocate memory for the BaseState
     void define(const int num_levs, const int length, const int ncomp=1);
 
@@ -50,22 +144,6 @@ public:
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     int nComp() const { return nvar; };
-
-    /// returns a reference to the nth component at position i and level lev.
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    T& operator() (int lev, int i, int n=0) const;
-
-    AMREX_GPU_HOST_DEVICE inline
-    T* operator() (const int lev, const int i, const int ncomp, const int start_comp);
-
-    AMREX_GPU_HOST_DEVICE inline
-    T* ptr (const int lev, const int i, const int n=0);
-
-    AMREX_GPU_HOST_DEVICE inline
-    T& operator[](const int i) { return dptr[i]; };
-
-    AMREX_GPU_HOST_DEVICE inline
-    const T& operator[](const int i) const { return dptr[i]; };
 
     /// scalar addition to the whole base state 
     template <class U>
@@ -119,8 +197,6 @@ protected:
 
     amrex::Gpu::ManagedVector<T> base_data;
 
-    T*  dptr;
-
     int nlev;
     int nvar;
     int len;    
@@ -131,7 +207,6 @@ BaseState<T>::BaseState(const int num_levs, const int length, const int ncomp)
 : nlev(num_levs), len(length), nvar(ncomp)
 {
     base_data.resize(nlev*len*nvar);
-    dptr = base_data.dataPtr();
 }
 
 template <class T>
@@ -139,7 +214,6 @@ BaseState<T>::BaseState(const amrex::Gpu::ManagedVector<T>& src, const int num_l
 : nlev(num_levs), len(length), nvar(ncomp)
 {
     base_data.resize(nlev*len*nvar);
-    dptr = base_data.dataPtr();
     // need to switch from Fortran array-ordering to C++ ordering
     for (auto l = 0; l < nlev; ++l) {
         for (auto r = 0; r < len; ++r) {
@@ -155,7 +229,6 @@ BaseState<T>::BaseState(const amrex::Vector<T>& src, const int num_levs, const i
 : nlev(num_levs), len(length), nvar(ncomp)
 {
     base_data.resize(nlev*len*nvar);
-    dptr = base_data.dataPtr();
     // need to switch from Fortran array-ordering to C++ ordering
     for (auto l = 0; l < nlev; ++l) {
         for (auto r = 0; r < len; ++r) {
@@ -171,9 +244,14 @@ BaseState<T>::BaseState(const BaseState<T>& src)
 : nlev(src.nLevels()), len(src.length()), nvar(src.nComp())
 {
     base_data.resize(nlev*len*nvar);
-    dptr = base_data.dataPtr();
-    for (auto i = 0; i < nlev*len*nvar; i++) {
-        base_data[i] = src[i];
+    BaseStateArray<T> base_arr = this->array();
+    const BaseStateArray<const T> src_arr = src.array();
+    for (auto l = 0; l < nlev; ++l) {
+        for (auto r = 0; r < len; ++r) {
+            for (auto n = 0; n < nvar; ++n) {
+                base_arr(l,r,n) = src_arr(l,r,n);
+            }
+        }
     }
 }
 
@@ -186,16 +264,15 @@ BaseState<T>::define(const int num_levs, const int length, const int ncomp)
     nvar = ncomp;
 
     base_data.resize(nlev*len*nvar);
-    dptr = base_data.dataPtr();
 }
 
 template <class T>
 void
 BaseState<T>::setVal(const T val)
 {
-    T * AMREX_RESTRICT ptr = dptr;
+    BaseStateArray<T> base_arr = this->array();
     AMREX_PARALLEL_FOR_1D(nvar*len*nlev, i, {
-        ptr[i] = val;
+        base_arr(i) = val;
     });
 
     amrex::Gpu::synchronize();
@@ -205,56 +282,12 @@ template <class T>
 void
 BaseState<T>::setVal(const int comp, const T val)
 {
-    T * AMREX_RESTRICT ptr = dptr;
-    const auto ncomp = nvar;
+    BaseStateArray<T> base_arr = this->array();
     AMREX_PARALLEL_FOR_1D(len*nlev, i, {
-        ptr[comp + i*ncomp] = val;
+        base_arr(0,i,comp) = val;
     });
 
     amrex::Gpu::synchronize();
-}
-
-template <class T>
-AMREX_GPU_HOST_DEVICE inline
-T&
-BaseState<T>::operator() (int lev, int i, int n) const {
-    AMREX_ASSERT(lev >= 0);
-    AMREX_ASSERT(i < this->len && i >= 0);
-    AMREX_ASSERT(n < this->nvar && n >= 0);
-
-    return dptr[(lev*len + i)*nvar + n];
-}
-
-template <class T>
-AMREX_GPU_HOST_DEVICE inline
-T* 
-BaseState<T>::operator() (const int lev, const int i, const int ncomp, const int start_comp) {
-    AMREX_ASSERT(lev >= 0);
-    AMREX_ASSERT(i < this->len && i >= 0);
-    AMREX_ASSERT(ncomp < this->nvar && ncomp > 0);
-    AMREX_ASSERT(start_comp < this-> nvar && start_comp >= 0);
-    AMREX_ASSERT(ncomp+start_comp < this->nvar);
-
-    amrex::Gpu::ManagedVector<T> vec(ncomp);
-
-    for (auto comp = 0; comp < ncomp; ++comp) {
-        vec[comp] = dptr[(lev*len + i)*nvar + start_comp+comp];
-    }
-
-    return vec.dataPtr();
-}
-
-template <class T>
-AMREX_GPU_HOST_DEVICE inline
-T*
-BaseState<T>::ptr (const int lev, const int i, const int n) {
-    AMREX_ASSERT(lev >= 0);
-    AMREX_ASSERT(i < this->len && i >= 0);
-    AMREX_ASSERT(n < this->nvar && n >= 0);
-
-    T* p = dptr[(lev*len + i)*nvar + n];
-
-    return p;
 }
 
 
@@ -270,9 +303,9 @@ operator+ (const T val, const BaseState<T>& p) {
 template <class T>
 BaseState<T>&
 BaseState<T>::operator+= (const T val) {
-    T * AMREX_RESTRICT ptr = dptr;
+    BaseStateArray<T> base_arr = this->array();
     AMREX_PARALLEL_FOR_1D(nvar*len*nlev, i, {
-        ptr[i] += val;
+        base_arr(i) += val;
     });
     amrex::Gpu::synchronize();
     return *this;
@@ -294,10 +327,10 @@ BaseState<T>::operator+= (const BaseState<T>& rhs) {
     AMREX_ASSERT(nvar == rhs.nvar);
     AMREX_ASSERT(len == rhs.len);
 
-    T * AMREX_RESTRICT ptr = dptr;
-    T * AMREX_RESTRICT rhs_ptr = rhs.dptr;
+    BaseStateArray<T> base_arr = this->array();
+    const BaseStateArray<const T> rhs_arr = rhs.array();
     AMREX_PARALLEL_FOR_1D(nvar*len*nlev, i, {
-        ptr[i] += rhs_ptr[i];
+        base_arr(i) += rhs_arr(i);
     });
     amrex::Gpu::synchronize();
     return *this;
@@ -315,10 +348,11 @@ operator- (const T val, const BaseState<T>& p) {
 template <class T>
 BaseState<T>&
 BaseState<T>::operator-= (const T val) {
-    T * AMREX_RESTRICT ptr = dptr;
+    BaseStateArray<T> base_arr = this->array();
     AMREX_PARALLEL_FOR_1D(nvar*len*nlev, i, {
-        ptr[i] -= val;
+        base_arr(i) -= val;
     });
+    amrex::Gpu::synchronize();
     return *this;
 }
 
@@ -338,10 +372,10 @@ BaseState<T>::operator-= (const BaseState<T>& rhs) {
     AMREX_ASSERT(nvar == rhs.nvar);
     AMREX_ASSERT(len == rhs.len);
 
-    T * AMREX_RESTRICT ptr = dptr;
-    T * AMREX_RESTRICT rhs_ptr = rhs.dptr;
+    BaseStateArray<T> base_arr = this->array();
+    const BaseStateArray<const T> rhs_arr = rhs.array();
     AMREX_PARALLEL_FOR_1D(nvar*len*nlev, i, {
-        ptr[i] -= rhs_ptr[i];
+        base_arr(i) -= rhs_arr(i);
     });
     amrex::Gpu::synchronize();
     return *this;
@@ -360,10 +394,11 @@ operator* (const T val, const BaseState<T>& p) {
 template <class T>
 BaseState<T>&
 BaseState<T>::operator*= (const T val) {
-    T * AMREX_RESTRICT ptr = dptr;
+    BaseStateArray<T> base_arr = this->array();
     AMREX_PARALLEL_FOR_1D(nvar*len*nlev, i, {
-        ptr[i] *= val;
+        base_arr(i) *= val;
     });
+    amrex::Gpu::synchronize();
     return *this;
 }
 
@@ -383,10 +418,10 @@ BaseState<T>::operator*= (const BaseState<T>& rhs) {
     AMREX_ASSERT(nvar == rhs.nvar);
     AMREX_ASSERT(len == rhs.len);
 
-    T * AMREX_RESTRICT ptr = dptr;
-    T * AMREX_RESTRICT rhs_ptr = rhs.dptr;
+    BaseStateArray<T> base_arr = this->array();
+    const BaseStateArray<const T> rhs_arr = rhs.array();
     AMREX_PARALLEL_FOR_1D(nvar*len*nlev, i, {
-        ptr[i] *= rhs_ptr[i];
+        base_arr(i) *= rhs_arr(i);
     });
     amrex::Gpu::synchronize();
     return *this;
@@ -404,9 +439,9 @@ operator/ (const T val, const BaseState<T>& p) {
 template <class T>
 BaseState<T>&
 BaseState<T>::operator/= (const T val) {
-    T * AMREX_RESTRICT ptr = dptr;
+    BaseStateArray<T> base_arr = this->array();
     AMREX_PARALLEL_FOR_1D(nvar*len*nlev, i, {
-        ptr[i] /= val;
+        base_arr(i) /= val;
     });
     amrex::Gpu::synchronize();
     return *this;
@@ -428,10 +463,10 @@ BaseState<T>::operator/= (const BaseState<T>& rhs) {
     AMREX_ASSERT(nvar == rhs.nvar);
     AMREX_ASSERT(len == rhs.len);
 
-    T * AMREX_RESTRICT ptr = dptr;
-    T * AMREX_RESTRICT rhs_ptr = rhs.dptr;
+    BaseStateArray<T> base_arr = this->array();
+    const BaseStateArray<const T> rhs_arr = rhs.array();
     AMREX_PARALLEL_FOR_1D(nvar*len*nlev, i, {
-        ptr[i] /= rhs_ptr[i];
+        base_arr(i) /= rhs_arr(i);
     });
     amrex::Gpu::synchronize();
     return *this;
@@ -444,8 +479,11 @@ operator== (const BaseState<T>& lhs, const BaseState<T>& rhs) {
     AMREX_ASSERT(lhs.nvar == rhs.nvar);
     AMREX_ASSERT(lhs.len == rhs.len);
 
+    const BaseStateArray<const T> lhs_arr = lhs.array();
+    const BaseStateArray<const T> rhs_arr = rhs.array();
+
     for (auto i = 0; i < lhs.nvar*lhs.len*lhs.nlev; ++i) {
-        if (lhs[i] != rhs[i]) {
+        if (lhs_arr(i) != rhs_arr(i)) {
             return false;
         }
     }
@@ -459,8 +497,11 @@ operator!= (const BaseState<T>& lhs, const BaseState<T>& rhs) {
     AMREX_ASSERT(lhs.nvar == rhs.nvar);
     AMREX_ASSERT(lhs.len == rhs.len);
 
+    const BaseStateArray<const T> lhs_arr = lhs.array();
+    const BaseStateArray<const T> rhs_arr = rhs.array();
+
     for (auto i = 0; i < lhs.nvar*lhs.len*lhs.nlev; ++i) {
-        if (lhs[i] != rhs[i]) {
+        if (lhs_arr(i) != rhs_arr(i)) {
             return true;
         }
     }

--- a/sphinx_docs/source/base_state.rst
+++ b/sphinx_docs/source/base_state.rst
@@ -1,0 +1,77 @@
+**********
+Base State
+**********
+
+``BaseState`` and ``BaseStateArray``
+====================================
+
+In AMReX, grid data is stored in FABs. Data in individual cells can then be accessed using an ``Array4``, e.g. 
+
+.. code-block:: cpp
+
+   MultiFab mf; // collection of FABs
+   const int ncomp = mf.nComp();
+
+   // iterate over FABs
+   for (MFIter mfi(mf, TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+
+       const Box& bx = mfi.tilebox();
+       const Array4<Real>& arr = mf.array(mfi);
+
+       AMREX_PARALLEL_FOR_4D(bx, ncomp, i, j, k, n,
+       {
+           arr(i,j,k,n) += 1;
+       });
+   }
+
+In MAESTROeX, we use a similar technique to store and access the base state. Instead of a FAB, the base state is stored in a ``BaseState`` object. The ``BaseState`` class is templated, so the data stored in a ``BaseState`` object can be anything that acts like a scalar number (i.e. has routines defining basic arithmetic and logical operations). 
+
+The ``BaseState`` object can have 1, 2 or 3 dimensions, allowing it represent data on multiple levels, a single level, and/or with multiple components. 
+
+Instead of accessing data in individual cells using and ``Array4``, for a ``BaseState`` object we use a ``BaseStateArray``. For example
+
+.. code-block:: cpp
+
+   // create a BaseState object containing Reals 
+   // with 2 levels, 25 cells per level and 3 components
+   const int nlev = 2;
+   const int ncells = 25;
+   const int ncomp = 3;
+
+   BaseState<Real> base_state(nlev, ncells, ncomp);
+   const BaseStateArr<Real> base_arr = base_state.array(); 
+
+   for (auto l = 0; l < nlev; ++l) {
+       AMREX_PARALLEL_FOR_1D(ncells, r,
+       {
+           base_arr(l,r,0) = 0.0;
+           base_arr(l,r,1) = 1.0;
+           base_arr(l,r,2) = 2.0;
+       });
+   }
+   Gpu::synchronize();
+
+Note here that we **must** call ``Gpu::synchronize()`` after the GPU kernel. For FABS, the ``MFIter`` loop calls ``Gpu::synchronize()`` at the end to ensure that all GPU streams are complete before moving on. However, as we often iterate over the base state outside of an ``MFIter`` loop, it's necessary that we call it explicitly here. 
+
+
+``BaseState`` arithmetic
+========================
+
+If performing simple arithmetic with ``BaseState``s, then this can be done straightforwardly using the built in member functions. ``BaseState``s can be added, subtracted, multiplied and divided by scalars and element-wise by other ``BaseState``s.
+
+.. code-block::
+
+   const int nlevs = 5;
+   const int ncells = 20;
+
+   // if we don't define the number of components, it defaults to 1
+   BaseState<Real> base_state(nlevs, ncells);
+   BaseState<Real> other_state(base_state); // copy constructor performs a deep copy 
+
+   base_state.setVal(0.0); // set all cells to 0.0
+   other_state.setVal(1.0); // set all cells to 1.0
+
+   base_state += 0.5; 
+   
+   BaseState<Real> another_state = base_state * (other_state - 2.5);
+

--- a/sphinx_docs/source/base_state.rst
+++ b/sphinx_docs/source/base_state.rst
@@ -59,7 +59,7 @@ Note here that we **must** call ``Gpu::synchronize()`` after the GPU kernel. For
 
 If performing simple arithmetic with ``BaseState``s, then this can be done straightforwardly using the built in member functions. ``BaseState``s can be added, subtracted, multiplied and divided by scalars and element-wise by other ``BaseState``s.
 
-.. code-block::
+.. code-block:: cpp
 
    const int nlevs = 5;
    const int ncells = 20;

--- a/sphinx_docs/source/index.rst
+++ b/sphinx_docs/source/index.rst
@@ -27,6 +27,7 @@ MAESTROeX: a low Mach number stellar hydrodynamics code
    param_intro
    initial_models
    gpu
+   base_state
    visualization
    analysis
    makefiles


### PR DESCRIPTION
This defines the `BaseStateArray` struct as an interface for accessing the individual cell data in the `BaseState`. This is necessary to get the correct performance of the `BaseState` when it's accessed from within a lambda region. The interface is similar to that of `Array4`. 

A page is added to the docs which explains how `BaseState` and `BaseStateArray` work. 

This PR does not change any of the main simulation code so will not affect the test suite. 