### PR TITLE
Optionally scale the ODE tolerances with SDC iteration for simplified SDC

### DIFF
--- a/Source/Maestro.H
+++ b/Source/Maestro.H
@@ -1467,7 +1467,8 @@ public:
                    const RealVector& p0,
                    const amrex::Real dt_react,
                    const amrex::Real time_react,
-                   amrex::Vector<amrex::MultiFab>& source);
+                   amrex::Vector<amrex::MultiFab>& source,
+                   const int sdc_iter, const int number_sdc_iterations);
 
 #ifndef SDC
     void Burner (const amrex::Vector<amrex::MultiFab>& s_in,
@@ -1485,7 +1486,8 @@ public:
                  const RealVector& p0,
                  const amrex::Real dt_react,
                  const amrex::Real time_react,
-                 const amrex::Vector<amrex::MultiFab>& source);
+                 const amrex::Vector<amrex::MultiFab>& source,
+                 const int sdc_iter, const int number_sdc_iterations);
 #endif
     
     // compute heating terms, rho_omegadot and rho_Hnuc

--- a/Source/MaestroAdvanceSdc.cpp
+++ b/Source/MaestroAdvanceSdc.cpp
@@ -522,7 +522,7 @@ Maestro::AdvanceTimeStepSDC (bool is_initIter) {
     // wallclock time
     Real start_total_react = ParallelDescriptor::second();
     
-    ReactSDC(sold,snew,rho_Hext,p0_old,dt,t_old,sdc_source);
+    ReactSDC(sold,snew,rho_Hext,p0_old,dt,t_old,sdc_source,0,0);
 
     // wallclock time
     Real end_total_react = ParallelDescriptor::second() - start_total_react;
@@ -960,7 +960,7 @@ Maestro::AdvanceTimeStepSDC (bool is_initIter) {
         // wallclock time
         Real start_total_react_corrector = ParallelDescriptor::second();
     
-        ReactSDC(sold,snew,rho_Hext,p0_new,dt,t_old,sdc_source);
+        ReactSDC(sold,snew,rho_Hext,p0_new,dt,t_old,sdc_source,misdc,sdc_iters);
 
         // wallclock time
         Real end_total_react_corrector = ParallelDescriptor::second() - start_total_react_corrector;

--- a/Source/MaestroAdvanceSdc.cpp
+++ b/Source/MaestroAdvanceSdc.cpp
@@ -522,7 +522,7 @@ Maestro::AdvanceTimeStepSDC (bool is_initIter) {
     // wallclock time
     Real start_total_react = ParallelDescriptor::second();
     
-    ReactSDC(sold,snew,rho_Hext,p0_old,dt,t_old,sdc_source,0,0);
+    ReactSDC(sold,snew,rho_Hext,p0_old,dt,t_old,sdc_source,0,1);
 
     // wallclock time
     Real end_total_react = ParallelDescriptor::second() - start_total_react;

--- a/Source/MaestroInit.cpp
+++ b/Source/MaestroInit.cpp
@@ -733,7 +733,7 @@ void Maestro::DivuIterSDC (int istep_divu_iter)
         sdc_source[lev].setVal(0.);
     }
     
-    ReactSDC(sold,stemp,rho_Hext,p0_old,0.5*dt,t_old,sdc_source);
+    ReactSDC(sold,stemp,rho_Hext,p0_old,0.5*dt,t_old,sdc_source,0,1);
     
     if (use_thermal_diffusion) {
         MakeThermalCoeffs(sold,Tcoeff,hcoeff,Xkcoeff,pcoeff);

--- a/Source/MaestroPlot.cpp
+++ b/Source/MaestroPlot.cpp
@@ -358,9 +358,9 @@ Maestro::PlotFileMF (const int nPlot,
     }
 #else   
     if (dt_in < small_dt) {
-        ReactSDC(s_in, stemp, rho_Hext, p0_in, small_dt, t_in, sdc_source);
+        ReactSDC(s_in, stemp, rho_Hext, p0_in, small_dt, t_in, sdc_source, 0, 1);
     } else {
-        ReactSDC(s_in, stemp, rho_Hext, p0_in, dt_in*0.5, t_in, sdc_source);
+        ReactSDC(s_in, stemp, rho_Hext, p0_in, dt_in*0.5, t_in, sdc_source, 0, 1);
     }
     
     MakeReactionRates(rho_omegadot,rho_Hnuc,s_in);

--- a/Source/MaestroReact.cpp
+++ b/Source/MaestroReact.cpp
@@ -102,7 +102,9 @@ Maestro::ReactSDC (const Vector<MultiFab>& s_in,
                    const RealVector& p0,
                    const Real dt_in,
                    const Real time_in,
-                   Vector<MultiFab>& source)
+                   Vector<MultiFab>& source,
+                   const int sdc_iter,
+                   const int number_sdc_iterations)
 {
     // timer for profiling
     BL_PROFILE_VAR("Maestro::ReactSDC()",ReactSDC);
@@ -139,7 +141,7 @@ Maestro::ReactSDC (const Vector<MultiFab>& s_in,
     if (do_burning) {
 #ifdef SDC
         // do the burning, update s_out
-        Burner(s_in,s_out,p0,dt_in,time_in,source);
+        Burner(s_in,s_out,p0,dt_in,time_in,source,sdc_iter,number_sdc_iterations);
 #endif
         // pass temperature through for seeding the temperature update eos call
         for (int lev=0; lev<=finest_level; ++lev) {
@@ -265,7 +267,9 @@ void Maestro::Burner(const Vector<MultiFab>& s_in,
                      const RealVector& p0,
                      const Real dt_in,
                      const Real time_in,
-                     const Vector<MultiFab>& source)
+                     const Vector<MultiFab>& source,
+                     const int sdc_iter,
+                     const int number_sdc_iterations)
 {
     // timer for profiling
     BL_PROFILE_VAR("Maestro::BurnerSDC()",BurnerSDC);
@@ -321,7 +325,8 @@ void Maestro::Burner(const Vector<MultiFab>& s_in,
                     BL_TO_FORTRAN_ANYD(s_out_mf[mfi]),
                     BL_TO_FORTRAN_ANYD(source_mf[mfi]),
                     BL_TO_FORTRAN_ANYD(p0_cart_mf[mfi]), dt_in, time_in,
-                    BL_TO_FORTRAN_ANYD(mask[mfi]), use_mask);
+                    BL_TO_FORTRAN_ANYD(mask[mfi]), use_mask,
+                    sdc_iter, number_sdc_iterations);
             } else {
 #pragma gpu box(tileBox)
                 burner_loop(AMREX_INT_ANYD(tileBox.loVect()), 
@@ -331,7 +336,8 @@ void Maestro::Burner(const Vector<MultiFab>& s_in,
                     BL_TO_FORTRAN_ANYD(s_out_mf[mfi]),
                     BL_TO_FORTRAN_ANYD(source_mf[mfi]), 
                     p0.dataPtr(), dt_in, time_in,
-                    BL_TO_FORTRAN_ANYD(mask[mfi]), use_mask);
+                    BL_TO_FORTRAN_ANYD(mask[mfi]), use_mask,
+                    sdc_iter, number_sdc_iterations);
             }
         }
     }

--- a/Source/Maestro_F.H
+++ b/Source/Maestro_F.H
@@ -122,7 +122,7 @@ extern "C"
                          const amrex::Real dt_in,
                          const amrex::Real time_in,
                          const int* mask, const int* m_lo, const int* m_hi,
-                         const int use_mask);
+                         const int use_mask, const int sdc_iter, const int number_sdc_iterations);
 
     void burner_loop_sphr(const int* lo, const int* hi,
                               const amrex::Real* s_in,     const int* i_lo, const int* i_hi,
@@ -132,7 +132,7 @@ extern "C"
                               const amrex::Real dt_in,
                               const amrex::Real time_in,
                               const int* mask, const int* m_lo, const int* m_hi,
-                              const int use_mask);
+                              const int use_mask, const int sdc_iter, const int number_sdc_iterations);
 #endif
     
     void instantaneous_reaction_rates(const int* lo, const int* hi,

--- a/Source/Src_nd/burner_loop.F90
+++ b/Source/Src_nd/burner_loop.F90
@@ -352,7 +352,8 @@ contains
        s_out,    o_lo, o_hi, &
        source,   s_lo, s_hi, &
        p0_in, dt_in, time_in, &
-       mask,     m_lo, m_hi, use_mask) &
+       mask,     m_lo, m_hi, use_mask,
+       sdc_iter, number_sdc_iterations) &
        bind (C,name="burner_loop")
 
     use sdc_type_module, only: sdc_t
@@ -372,6 +373,7 @@ contains
     double precision, value, intent (in) :: time_in
     integer         , intent (in   ) :: mask(m_lo(1):m_hi(1),m_lo(2):m_hi(2),m_lo(3):m_hi(3))
     integer, value  , intent (in   ) :: use_mask
+    integer, value  , intent (in   ) :: sdc_iter, number_sdc_iterations
 
     ! local
     integer          :: i, j, k, r
@@ -440,6 +442,8 @@ contains
                    state_in % j = j
                    state_in % k = k
                    state_in % success = .true.
+                   state_in % sdc_iter = sdc_iter
+                   state_in % num_sdc_iter = number_sdc_iterations
 
                    call integrator(state_in, state_out, dt_in, time_in)
                    
@@ -475,7 +479,8 @@ contains
        s_out,    o_lo, o_hi, &
        source,   s_lo, s_hi, &
        p0_cart, t_lo, t_hi, dt_in, time_in, &
-       mask,     m_lo, m_hi, use_mask) &
+       mask,     m_lo, m_hi, use_mask,
+       sdc_iter, number_sdc_iterations) &
        bind (C,name="burner_loop_sphr")
 
     use sdc_type_module, only: sdc_t
@@ -495,6 +500,7 @@ contains
     double precision, value, intent (in) :: time_in
     integer         , intent (in   ) :: mask(m_lo(1):m_hi(1),m_lo(2):m_hi(2),m_lo(3):m_hi(3))
     integer, value  , intent (in   ) :: use_mask
+    integer, value  , intent (in   ) :: sdc_iter, number_sdc_iterations
 
     ! local
     integer          :: i, j, k
@@ -558,6 +564,9 @@ contains
                    state_in % i = i
                    state_in % j = j
                    state_in % k = k
+                   state_in % success = .true.
+                   state_in % sdc_iter = sdc_iter
+                   state_in % num_sdc_iter = number_sdc_iterations
 
                    call integrator(state_in, state_out, dt_in, time_in)
 

--- a/Source/Src_nd/burner_loop.F90
+++ b/Source/Src_nd/burner_loop.F90
@@ -443,7 +443,7 @@ contains
                    state_in % k = k
                    state_in % success = .true.
                    state_in % sdc_iter = sdc_iter
-                   state_in % num_sdc_iter = number_sdc_iterations
+                   state_in % num_sdc_iters = number_sdc_iterations
 
                    call integrator(state_in, state_out, dt_in, time_in)
                    
@@ -566,7 +566,7 @@ contains
                    state_in % k = k
                    state_in % success = .true.
                    state_in % sdc_iter = sdc_iter
-                   state_in % num_sdc_iter = number_sdc_iterations
+                   state_in % num_sdc_iters = number_sdc_iterations
 
                    call integrator(state_in, state_out, dt_in, time_in)
 


### PR DESCRIPTION
For simplified SDC, this now initializes the current SDC iteration number and the total number of SDC iterations in the sdc_t derived type passed to the ODE integrator.

This allows the user to scale ODE solver tolerances with the SDC iteration number as described in Microphysics PR 309 here: https://github.com/starkiller-astro/Microphysics/pull/309