### PR TITLE
Probin fix/hack

### DIFF
--- a/Exec/Make.Maestro
+++ b/Exec/Make.Maestro
@@ -98,7 +98,7 @@ endif
 # directories into VPATH_LOCATIONS and INCLUDE_LOCATIONS for us, so we
 # don't need to do it here
 
-Pdirs 	:= Base Boundary AmrCore LinearSolvers/C_CellMG LinearSolvers/MLMG
+Pdirs 	:= Base Boundary AmrCore LinearSolvers/C_CellMG LinearSolvers/MLMG F_Interfaces/Base
 
 Bpack	+= $(foreach dir, $(Pdirs), $(AMREX_HOME)/Src/$(dir)/Make.package)
 

--- a/Source/MaestroSetup.cpp
+++ b/Source/MaestroSetup.cpp
@@ -290,7 +290,9 @@ Maestro::ExternInit ()
 
     if (ParallelDescriptor::IOProcessor()) {
         std::cout << "reading extern runtime parameters ..." << std::endl;
+        maestro_write_probin();
     }
+    ParallelDescriptor::Barrier();
 
     maestro_extern_init();
 

--- a/Source/Maestro_F.H
+++ b/Source/Maestro_F.H
@@ -292,6 +292,7 @@ extern "C"
     void maestro_network_init();
     void maestro_eos_init();
     void maestro_extern_init();
+    void maestro_write_probin();
     void maestro_conductivity_init();
     void get_num_spec(int* nspec);
     void get_spec_names(int* spec_names, int* ispec, int* len);

--- a/Source/Src_nd/maestro_init.F90
+++ b/Source/Src_nd/maestro_init.F90
@@ -79,7 +79,6 @@ contains
     ! initialize the external runtime parameters in
     ! extern_probin_module
     ! Binds to C function ``maestro_extern_init``
-    use amrex_fort_module, only: rt => amrex_real
     !
     call runtime_init()
 

--- a/Source/param/runtime.probin.template
+++ b/Source/param/runtime.probin.template
@@ -46,38 +46,55 @@ module runtime_init_module
 
   public :: probin
 
-  public :: runtime_init, runtime_close, runtime_pretty_print
+  public :: write_probin, runtime_init, runtime_close, runtime_pretty_print
 
 contains
 
-subroutine runtime_init()
-
-  use amrex_parallel_module, only: amrex_parallel_ioprocessor
+subroutine write_probin() bind(C, name="maestro_write_probin")
 
   implicit none
 
   integer :: status, un
-  character(len=250), probin_f
+  character(len=250) probin_f
+  un = 1
+
+  ! we're going to write the probin to a file because the PGI compiler doesn't like 
+  ! reading namelists from arrays
+  probin_f = "probin"
+  open(newunit=un, file=probin_f, action='write')
+  write(un, *) amrex_namelist
+  close(un)
+
+end subroutine write_probin
+
+
+subroutine runtime_init()
+
+  use amrex_parallel_module
+
+  implicit none
+
+  integer :: status, un
+  character(len=250) probin_f
   un = 1
 
   @@allocations@@
 
   @@defaults@@
 
-  ! we're going to write the probin to a file because the PGI compiler doesn't like 
-  ! reading namelists from arrays
-  probin_f = "probin"
-  if (amrex_parallel_ioprocessor()) then
-    open(newunit=un, file=probin_f, action='write')
-    write(un, *) amrex_namelist
-    close(un)
-  endif
-
   !   print*, amrex_namelist
   !   read (amrex_namelist, nml=probin, iostat=status)
+
+  probin_f = "probin"
   open(newunit=un, file=probin_f, status='old', action='read')
   read (unit=un, nml=probin, iostat=status)
-  close(un, status='delete')
+  close(un)
+
+  ! delete file 
+  if (amrex_parallel_ioprocessor()) then
+    open(newunit=un, file=probin_f, status='old', action='read')
+    close(un, status='delete')
+  endif
 
   if (status .ne. 0) then
      ! some problem in the namelist

--- a/Source/param/runtime.probin.template
+++ b/Source/param/runtime.probin.template
@@ -54,13 +54,26 @@ subroutine runtime_init()
 
   implicit none
 
-  integer :: status
+  integer :: status, un
+  character*250, probin_f
+  un = 1
 
   @@allocations@@
 
   @@defaults@@
 
-  read (amrex_namelist, nml=probin, iostat=status)
+  ! we're going to write the probin to a file because the PGI compiler doesn't like 
+  ! reading namelists from arrays
+  probin_f = "tmp_build_dir/maestroex_sources/probin"
+  open(newunit=un, file=probin_f, action='write')
+  write(un, *) amrex_namelist
+  close(un)
+
+  !   print*, amrex_namelist
+  !   read (amrex_namelist, nml=probin, iostat=status)
+  open(newunit=un, file=probin_f, status='old', action='read')
+  read (unit=un, nml=probin, iostat=status)
+  close(un)
 
   if (status .ne. 0) then
      ! some problem in the namelist

--- a/Source/param/runtime.probin.template
+++ b/Source/param/runtime.probin.template
@@ -52,10 +52,12 @@ contains
 
 subroutine runtime_init()
 
+  use amrex_parallel_module, only: amrex_parallel_ioprocessor
+
   implicit none
 
   integer :: status, un
-  character*250, probin_f
+  character(len=250), probin_f
   un = 1
 
   @@allocations@@
@@ -64,16 +66,18 @@ subroutine runtime_init()
 
   ! we're going to write the probin to a file because the PGI compiler doesn't like 
   ! reading namelists from arrays
-  probin_f = "tmp_build_dir/maestroex_sources/probin"
-  open(newunit=un, file=probin_f, action='write')
-  write(un, *) amrex_namelist
-  close(un)
+  probin_f = "probin"
+  if (amrex_parallel_ioprocessor()) then
+    open(newunit=un, file=probin_f, action='write')
+    write(un, *) amrex_namelist
+    close(un)
+  endif
 
   !   print*, amrex_namelist
   !   read (amrex_namelist, nml=probin, iostat=status)
   open(newunit=un, file=probin_f, status='old', action='read')
   read (unit=un, nml=probin, iostat=status)
-  close(un)
+  close(un, status='delete')
 
   if (status .ne. 0) then
      ! some problem in the namelist


### PR DESCRIPTION
When compiled with the PGI compiler, the variables contained in the probin namelist in the inputs file are not read in correctly. This appears to be due to the call to the `read` subroutine in `runtime_init`, which does not appear to work when given the character array `amex_namelist`. 

To fix this, this PR writes `amrex_namelist` to a file before reading it back in again. 