### PR TITLE
undo changes from probin_fix

### DIFF
--- a/Exec/Make.Maestro
+++ b/Exec/Make.Maestro
@@ -98,7 +98,7 @@ endif
 # directories into VPATH_LOCATIONS and INCLUDE_LOCATIONS for us, so we
 # don't need to do it here
 
-Pdirs 	:= Base Boundary AmrCore LinearSolvers/C_CellMG LinearSolvers/MLMG F_Interfaces/Base
+Pdirs 	:= Base Boundary AmrCore LinearSolvers/C_CellMG LinearSolvers/MLMG
 
 Bpack	+= $(foreach dir, $(Pdirs), $(AMREX_HOME)/Src/$(dir)/Make.package)
 

--- a/Source/MaestroReact.cpp
+++ b/Source/MaestroReact.cpp
@@ -286,8 +286,8 @@ void Maestro::Burner(const Vector<MultiFab>& s_in,
             Put1dArrayOnCart(p0, p0_cart, 0, 0, bcs_f, 0);
         }
     } else {
-	// need non-constant basestate to apply toVector()
-	BaseState<Real> p0_var(p0);
+        // need non-constant basestate to apply toVector()
+        BaseState<Real> p0_var(p0);
         p0_var.toVector(p0_vec);
     }
 

--- a/Source/MaestroSetup.cpp
+++ b/Source/MaestroSetup.cpp
@@ -290,9 +290,7 @@ Maestro::ExternInit ()
 
     if (ParallelDescriptor::IOProcessor()) {
         std::cout << "reading extern runtime parameters ..." << std::endl;
-        maestro_write_probin();
     }
-    ParallelDescriptor::Barrier();
 
     maestro_extern_init();
 

--- a/Source/Maestro_F.H
+++ b/Source/Maestro_F.H
@@ -292,7 +292,6 @@ extern "C"
     void maestro_network_init();
     void maestro_eos_init();
     void maestro_extern_init();
-    void maestro_write_probin();
     void maestro_conductivity_init();
     void get_num_spec(int* nspec);
     void get_spec_names(int* spec_names, int* ispec, int* len);

--- a/Source/param/runtime.probin.template
+++ b/Source/param/runtime.probin.template
@@ -46,55 +46,21 @@ module runtime_init_module
 
   public :: probin
 
-  public :: write_probin, runtime_init, runtime_close, runtime_pretty_print
+  public :: runtime_init, runtime_close, runtime_pretty_print
 
 contains
 
-subroutine write_probin() bind(C, name="maestro_write_probin")
-
-  implicit none
-
-  integer :: status, un
-  character(len=250) probin_f
-  un = 1
-
-  ! we're going to write the probin to a file because the PGI compiler doesn't like 
-  ! reading namelists from arrays
-  probin_f = "probin"
-  open(newunit=un, file=probin_f, action='write')
-  write(un, *) amrex_namelist
-  close(un)
-
-end subroutine write_probin
-
-
 subroutine runtime_init()
 
-  use amrex_parallel_module
 
-  implicit none
 
-  integer :: status, un
-  character(len=250) probin_f
-  un = 1
+  integer :: status
 
   @@allocations@@
 
   @@defaults@@
 
-  !   print*, amrex_namelist
-  !   read (amrex_namelist, nml=probin, iostat=status)
-
-  probin_f = "probin"
-  open(newunit=un, file=probin_f, status='old', action='read')
-  read (unit=un, nml=probin, iostat=status)
-  close(un)
-
-  ! delete file 
-  if (amrex_parallel_ioprocessor()) then
-    open(newunit=un, file=probin_f, status='old', action='read')
-    close(un, status='delete')
-  endif
+  read (amrex_namelist, nml=probin, iostat=status)
 
   if (status .ne. 0) then
      ! some problem in the namelist


### PR DESCRIPTION
Undo #192 
The reverted code now works with AMReX #902 fixing the PGI/IBM ParmParse bug