### PR TITLE
SDC use_tfromp=true fix

### DIFF
--- a/Source/MaestroDiag.cpp
+++ b/Source/MaestroDiag.cpp
@@ -74,7 +74,7 @@ Maestro::DiagFile (const int step,
         rho_Hnuc          [lev].define(grids[lev], dmap[lev],       1, 0);
         sdc_source        [lev].define(grids[lev], dmap[lev],   Nscal, 0);
 
-	sdc_source[lev].setVal(0.0);
+        sdc_source[lev].setVal(0.0);
     }
 
 #ifndef SDC
@@ -85,9 +85,9 @@ Maestro::DiagFile (const int step,
     }
 #else
     if (dt < small_dt) {
-	ReactSDC(s_in, stemp, rho_Hext, p0_in, small_dt, t_in, sdc_source);
+        ReactSDC(s_in, stemp, rho_Hext, p0_in, small_dt, t_in, sdc_source);
     } else {
-	ReactSDC(s_in, stemp, rho_Hext, p0_in, dt*0.5, t_in, sdc_source);
+        ReactSDC(s_in, stemp, rho_Hext, p0_in, dt*0.5, t_in, sdc_source);
     }
 
     MakeReactionRates(rho_omegadot,rho_Hnuc,s_in);

--- a/Source/MaestroReact.cpp
+++ b/Source/MaestroReact.cpp
@@ -18,7 +18,7 @@ Maestro::React (const Vector<MultiFab>& s_in,
                 const Real time_in)
 {
     // timer for profiling
-    BL_PROFILE_VAR("Maestro::React()",React);
+    BL_PROFILE_VAR("Maestro::React()", React);
 
     // external heating
     if (do_heating) {
@@ -282,9 +282,7 @@ void Maestro::Burner(const Vector<MultiFab>& s_in,
             p0_cart[lev].setVal(0.);
         }
 
-        if (drive_initial_convection) {
-            Put1dArrayOnCart(p0, p0_cart, 0, 0, bcs_f, 0);
-        }
+        Put1dArrayOnCart(p0, p0_cart, 0, 0, bcs_f, 0);
     } else {
         // need non-constant basestate to apply toVector()
         BaseState<Real> p0_var(p0);


### PR DESCRIPTION
This removes an if statement that meant the pressure used by the EoS if `use_tfromp=true` was not initialized.