### PR TITLE
Convert docs to use main branch instead of master

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -3,7 +3,7 @@ name: github pages
 on:
   push:
     branches:
-      - master
+      - main
       - development
 
 jobs:
@@ -42,9 +42,9 @@ jobs:
         run: python3 -m pip install -r ./requirements.txt
 
       - name: Build docs
-        if: ${{ endsWith(github.ref, 'master') }}
+        if: ${{ endsWith(github.ref, 'main') }}
         env:
-          GITHUB_BRANCH: 'master'
+          GITHUB_BRANCH: 'main'
         run: ./deploy_docs_action.sh
 
       - name: Build docs 

--- a/README.md
+++ b/README.md
@@ -96,13 +96,13 @@ Development generally follows the following ideas:
     change (or if they do, that the changes were expected).
 
     If a change is critical, we can cherry-pick the commit from
-    `development` to `master`.
+    `development` to `main`.
 
   * Contributions are welcomed from anyone.  *Any contributions that
     have the potential to change answers should be done via pull
     requests.*   A pull request should be generated from your fork of
     MAESTROeX and target the `development` branch.  (If you mistakenly
-    target `master`, we can change it for you.)
+    target `main`, we can change it for you.)
 
     If there are a number of small commits making up the PR, we may
     wish to squash commits upon merge to have a clean history.
@@ -110,14 +110,14 @@ Development generally follows the following ideas:
     since these will be used for a squashed commit message.*
 
   * On the first workday of each month, we perform a merge of
-    `development` into `master`, in coordination with `AMReX`,
+    `development` into `main`, in coordination with `AMReX`,
     `MAESTROeX`, and `Microphysics`.  For this merge to take place, we
     need to be passing the regression tests.
 
     To accommodate this need, we close the merge window into
     `development` a few days before the merge day.  While the merge
     window is closed, only bug fixes should be pushed into
-    `development`.  Once the merge from `development` -> `master` is
+    `development`.  Once the merge from `development` -> `main` is
     done, the merge window reopens.
 
 

--- a/deploy_docs_action.sh
+++ b/deploy_docs_action.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -e # Exit with nonzero exit code if anything fails
 
-# Build the documentation from the MASTER_BRANCH or DEV_BRANCH
+# Build the documentation from the MAIN_BRANCH or DEV_BRANCH
 # and push it to TARGET_BRANCH.
-MASTER_BRANCH="master"
+MAIN_BRANCH="main"
 DEV_BRANCH="development"
 TARGET_BRANCH="gh-pages"
 
@@ -21,7 +21,7 @@ make html
 cd ../
 
 mkdir -p out/docs/
-if [ "$GITHUB_BRANCH" = "$MASTER_BRANCH" ]; then
+if [ "$GITHUB_BRANCH" = "$MAIN_BRANCH" ]; then
     mv sphinx_docs/build/html/* out/docs
 else 
     mkdir -p out/docs/dev/

--- a/sphinx_docs/source/_templates/dev_layout.html
+++ b/sphinx_docs/source/_templates/dev_layout.html
@@ -6,6 +6,6 @@
 {% block sidebartitle %}
 {{ super() }}
     <div class="branch">
-        Branch: <a href="{{ pathto('../', 1) }}{{ pagename }}{{file_suffix}}">master</a> | <a href="{{ pathto('', 1) }}{{ pagename }}{{file_suffix}}">development</a>
+        Branch: <a href="{{ pathto('../', 1) }}{{ pagename }}{{file_suffix}}">main</a> | <a href="{{ pathto('', 1) }}{{ pagename }}{{file_suffix}}">development</a>
     </div>
 {% endblock %}

--- a/sphinx_docs/source/_templates/layout.html
+++ b/sphinx_docs/source/_templates/layout.html
@@ -6,6 +6,6 @@
 {% block sidebartitle %}
 {{ super() }}
     <div class="branch">
-        Branch: <a href="{{ pathto('', 1) }}{{ pagename }}{{file_suffix}}">master</a> | <a href="{{ pathto('', 1) }}dev/{{ pagename }}{{file_suffix}}">development</a>
+        Branch: <a href="{{ pathto('', 1) }}{{ pagename }}{{file_suffix}}">main</a> | <a href="{{ pathto('', 1) }}dev/{{ pagename }}{{file_suffix}}">development</a>
     </div>
 {% endblock %}

--- a/sphinx_docs/source/addproblem.rst
+++ b/sphinx_docs/source/addproblem.rst
@@ -93,7 +93,7 @@ override this default search path, you can set ``EOS_TOP_DIR``,
 Generally, one does not need to include the problem directory itself
 in ``Bpack`` and ``Blocs``, unless there are unique source files found there,
 described in a ``Make.package`` file. These variables are
-interpreted by the ``Make.Maestro`` file and used to build a master
+interpreted by the ``Make.Maestro`` file and used to build a main
 list of packages called Bdirs. The build system will attempt
 to build all of the files listed in the various ``Make.package``
 files found in the Bdirs directories. Furthermore,

--- a/sphinx_docs/source/architecture.rst.old
+++ b/sphinx_docs/source/architecture.rst.old
@@ -321,7 +321,7 @@ CONDUCTIVITY_TOP_DIR, and NETWORK_TOP_DIR respectively.
 Generally, one does not need to include the problem directory itself
 in EXTRA_DIR, unless there are unique source files found there,
 described in a GPackage.mak file. These variables are
-interpreted by the GMaestro.mak file and used to build a master
+interpreted by the GMaestro.mak file and used to build a main
 list of packages called Fmdirs. The build system will attempt
 to build all of the files listed in the various GPackage.mak
 files found in the Fmdirs directories. Furthermore,
@@ -345,7 +345,7 @@ compiled. This is a Fortran module that holds the values of the
 runtime parameters and makes them available to any routine. By
 default, the build system looks for a file called \_parameters
 in the problem directory and adds those parameters along with the
-master list of MAESTROeX parameters (MAESTROeX/_parameters) to
+main list of MAESTROeX parameters (MAESTROeX/_parameters) to
 the probin_module.
 
 The final line in the GNUmakefile includes the rules to actually

--- a/sphinx_docs/source/conf.py
+++ b/sphinx_docs/source/conf.py
@@ -73,8 +73,8 @@ source_suffix = '.rst'
 # see https://github.com/phn/pytpm/issues/3#issuecomment-12133978
 numpydoc_show_class_members = False
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = 'MAESTROeX'
@@ -200,7 +200,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'MAESTROeX.tex', 'MAESTROeX Documentation',
+    (main_doc, 'MAESTROeX.tex', 'MAESTROeX Documentation',
      'MAESTROeX development team', 'manual'),
 ]
 
@@ -210,7 +210,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'MAESTROeX', 'MAESTROeX Documentation',
+    (main_doc, 'MAESTROeX', 'MAESTROeX Documentation',
      [author], 1)
 ]
 
@@ -221,7 +221,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'MAESTROeX', 'MAESTROeX Documentation',
+    (main_doc, 'MAESTROeX', 'MAESTROeX Documentation',
      author, 'MAESTROeX', 'One line description of project.',
      'Miscellaneous'),
 ]

--- a/sphinx_docs/source/faq.rst
+++ b/sphinx_docs/source/faq.rst
@@ -206,7 +206,7 @@ Debugging
    We run `clang-tidy <https://clang.llvm.org/extra/clang-tidy/>`_ on all pull requests using a `GitHub action <https://github.com/AMReX-Astro/cpp-linter-action>`_. ``clang-tidy`` analyzes the source code, produces warnings for potential bugs and offers suggestions for performance improvements. 
 
    ``clang-tidy`` can also be run locally. This requires the ``clang-tidy`` and ``bear`` packages (installed using e.g. ``sudo apt install bear clang-tidy`` on Ubuntu), and the python script
-   ``run-clang-tidy.py`` (which can be downloaded from `here <https://github.com/AMReX-Astro/cpp-linter-action/blob/master/run-clang-tidy.py>`_). The analysis is performed by first compiling a problem using the ``bear`` package, then running the python script to analyze the source files. From within a problem directory, run
+   ``run-clang-tidy.py`` (which can be downloaded from `here <https://github.com/AMReX-Astro/cpp-linter-action/blob/main/run-clang-tidy.py>`_). The analysis is performed by first compiling a problem using the ``bear`` package, then running the python script to analyze the source files. From within a problem directory, run
 
    .. code-block:: bash
 

--- a/sphinx_docs/source/getting_started.rst
+++ b/sphinx_docs/source/getting_started.rst
@@ -352,19 +352,19 @@ directly with GNUplot, for example.
 Development Model
 =================
 
-When you clone MAESTROeX from github, you will be on the master
+When you clone MAESTROeX from github, you will be on the main
 branch of the repo. New changes to MAESTROeX are first introduced
 into the development branch in the MAESTROeX git repository.
 Nightly regression tests are run on development to ensure that
 our answers don’t change. Around the first work day of each month, we
-merge from development :math:`\rightarrow` master (assuming
+merge from development :math:`\rightarrow` main (assuming
 tests pass) and tag the state of the code with a date-based tag
 YY-MM. We do this on all the other repos in the AMReX-ecosystem,
 including amrex/, Microphysics/, and Castro/.
 
 If you want to contribute to MAESTROeX’s development, issue a pull-request
 through GitHub from your fork of MAESTROeX and target the development
-branch. (If you mistakenly target master, we can change it for you.)
+branch. (If you mistakenly target main, we can change it for you.)
 
 Parallel Jobs
 =============

--- a/sphinx_docs/source/index.rst
+++ b/sphinx_docs/source/index.rst
@@ -1,4 +1,4 @@
-.. pyro documentation master file, created by
+.. MAESTROeX documentation main file, created by
    sphinx-quickstart on Mon Dec 25 18:42:54 2017.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.


### PR DESCRIPTION
This converts the docs action to use the main branch instead of master, changes all mentions of the master branch in the docs to main and changes links which point to the master branch to point to the main branch.

This will break some links in the development docs until the master branch has been converted to main.