### PR TITLE
Smallscale sdc dpdt fix

### DIFF
--- a/Exec/science/flame/inputs_2d_smallscale
+++ b/Exec/science/flame/inputs_2d_smallscale
@@ -36,7 +36,7 @@ amr.refine_grid_layout = 0       # chop grids up into smaller grids if nprocs > 
 maestro.temperr = 6.5e8 6.5e8 6.5e8
 
 # TIME STEPPING
-maestro.max_step  = 30000000
+maestro.max_step  = 300000
 maestro.stop_time = 1.e0
 maestro.cfl       = 0.5    # cfl number for hyperbolic system
                            # In this test problem, the velocity is
@@ -62,16 +62,13 @@ maestro.use_thermal_diffusion = true
 maestro.init_shrink = 0.1e0
 maestro.max_dt_growth = 1.2e0
 
-maestro.use_tfromp = true
-maestro.dpdt_factor = 0.0e0
+maestro.use_tfromp = false
+maestro.dpdt_factor = 0.3
 
 # PLOTFILES
 maestro.plot_base_name  = flame_    # root name of plot file
-maestro.plot_int   = -1      # number of timesteps between plot files
+maestro.plot_int   = 10      # number of timesteps between plot files
 maestro.plot_deltat = 1.e-5
-maestro.small_plot_base_name = smallflame_
-maestro.small_plot_int = 100
-maestro.small_plot_deltat = 1.e-5
 
 # CHECKPOINT
 maestro.check_base_name = chk

--- a/Exec/science/flame/inputs_2d_smallscale_sdc
+++ b/Exec/science/flame/inputs_2d_smallscale_sdc
@@ -68,6 +68,9 @@ maestro.dpdt_factor = 1.
 maestro.sdc_iters = 1
 maestro.sdc_couple_mac_velocity = 1
 
+maestro.enthalpy_pred_type = 0
+maestro.species_pred_type = 2
+
 # PLOTFILES
 maestro.plot_base_name  = sdc_flame_    # root name of plot file
 maestro.plot_int   = 10      # number of timesteps between plot files

--- a/Exec/science/flame/inputs_2d_smallscale_sdc
+++ b/Exec/science/flame/inputs_2d_smallscale_sdc
@@ -65,21 +65,17 @@ maestro.max_dt_growth = 1.2e0
 maestro.use_tfromp = false
 maestro.dpdt_factor = 0.3e0
 
-maestro.ppm_type = 1
-maestro.enthalpy_pred_type = 3
-maestro.use_delta_gamma1_term = false
+maestro.sdc_iters = 1
+maestro.sdc_couple_mac_velocity = 1
 
 # PLOTFILES
 maestro.plot_base_name  = sdc_flame_    # root name of plot file
 maestro.plot_int   = 10      # number of timesteps between plot files
 maestro.plot_deltat = 1.e-5
-#maestro.small_plot_base_name = smallflame_
-#maestro.small_plot_int = 100
-#maestro.small_plot_deltat = 1.e-5
 
 # CHECKPOINT
 maestro.check_base_name = sdc_chk
-maestro.chk_int         = 1000
+maestro.chk_int         = -1
 
 # tolerances for the initial projection
 maestro.eps_init_proj_cart = 1.e-11

--- a/Exec/science/flame/inputs_2d_smallscale_sdc
+++ b/Exec/science/flame/inputs_2d_smallscale_sdc
@@ -63,7 +63,7 @@ maestro.init_shrink = 0.1e0
 maestro.max_dt_growth = 1.2e0
 
 maestro.use_tfromp = false
-maestro.dpdt_factor = 0.3e0
+maestro.dpdt_factor = 1.
 
 maestro.sdc_iters = 1
 maestro.sdc_couple_mac_velocity = 1

--- a/Exec/science/flame/inputs_2d_smallscale_sdc
+++ b/Exec/science/flame/inputs_2d_smallscale_sdc
@@ -68,9 +68,6 @@ maestro.dpdt_factor = 1.
 maestro.sdc_iters = 1
 maestro.sdc_couple_mac_velocity = 1
 
-maestro.enthalpy_pred_type = 0
-maestro.species_pred_type = 2
-
 # PLOTFILES
 maestro.plot_base_name  = sdc_flame_    # root name of plot file
 maestro.plot_int   = 10      # number of timesteps between plot files

--- a/Source/MaestroAdvanceAvg.cpp
+++ b/Source/MaestroAdvanceAvg.cpp
@@ -24,7 +24,6 @@ void Maestro::AdvanceTimeStepAverage(bool is_initIter) {
     Vector<MultiFab> s2star(finest_level + 1);
     Vector<MultiFab> delta_gamma1_term(finest_level + 1);
     Vector<MultiFab> delta_gamma1(finest_level + 1);
-    Vector<MultiFab> peosbar_cart(finest_level + 1);
     Vector<MultiFab> p0_cart(finest_level + 1);
     Vector<MultiFab> delta_p_term(finest_level + 1);
     Vector<MultiFab> Tcoeff(finest_level + 1);
@@ -117,7 +116,6 @@ void Maestro::AdvanceTimeStepAverage(bool is_initIter) {
         delta_gamma1_term[lev].define(grids[lev], dmap[lev], 1, 0);
         delta_gamma1[lev].define(grids[lev], dmap[lev], 1, 0);
         p0_cart[lev].define(grids[lev], dmap[lev], 1, 0);
-        peosbar_cart[lev].define(grids[lev], dmap[lev], 1, 0);
         delta_p_term[lev].define(grids[lev], dmap[lev], 1, 0);
         Tcoeff[lev].define(grids[lev], dmap[lev], 1, 1);
         hcoeff1[lev].define(grids[lev], dmap[lev], 1, 1);
@@ -265,7 +263,7 @@ void Maestro::AdvanceTimeStepAverage(bool is_initIter) {
     // no ghost cells for S_cc_nph
     AverageDown(S_cc_nph, 0, 1);
 
-    // compute p0_minus_peosbar = p0_old - peosbar (for making w0) and
+    // compute p0_minus_peosbar = p0_old - peosbar_old (for making w0) and
     // compute delta_p_term = peos_old - p0_old (for RHS of projections)
     if (dpdt_factor > 0.0) {
         // peos_old (delta_p_term) now holds the thermodynamic p computed from sold(rho,h,X)
@@ -277,13 +275,12 @@ void Maestro::AdvanceTimeStepAverage(bool is_initIter) {
         // compute p0_minus_peosbar = p0_old - peosbar
         p0_minus_peosbar.copy(p0_old - peosbar);
 
-        // compute peosbar_cart from peosbar
-        Put1dArrayOnCart(peosbar, peosbar_cart, false, false, bcs_f, 0);
+        // put p0_old on cart
+        Put1dArrayOnCart(p0_old, p0_cart, false, false, bcs_f, 0);
 
-        // compute delta_p_term = peos_old - peosbar_cart
+        // compute delta_p_term = peos_old - p0_old
         for (int lev = 0; lev <= finest_level; ++lev) {
-            MultiFab::Subtract(delta_p_term[lev], peosbar_cart[lev], 0, 0, 1,
-                               0);
+            MultiFab::Subtract(delta_p_term[lev], p0_cart[lev], 0, 0, 1, 0);
         }
     } else {
         // these should have no effect if dpdt_factor <= 0
@@ -569,9 +566,10 @@ void Maestro::AdvanceTimeStepAverage(bool is_initIter) {
     }
     AverageDown(S_cc_nph, 0, 1);
 
-    // and delta_p_term = peos_new - p0_new (for RHS of projection)
+    // compute p0_minus_peosbar = p0_new - peosbar_new (for making w0) and
+    // set delta_p_term = peos_new - p0_new (for RHS of projection)
     if (dpdt_factor > 0.) {
-        // peos_new now holds the thermodynamic p computed from snew(rho,h,X)
+        // peos now holds "peos_new", the thermodynamic p computed from snew(rho,h,X)
         PfromRhoH(snew, snew, delta_p_term);
 
         // compute peosbar = Avg(peos_new)
@@ -580,13 +578,12 @@ void Maestro::AdvanceTimeStepAverage(bool is_initIter) {
         // compute p0_minus_peosbar = p0_new - peosbar
         p0_minus_peosbar.copy(p0_new - peosbar);
 
-        // compute peosbar_cart from peosbar
-        Put1dArrayOnCart(peosbar, peosbar_cart, false, false, bcs_f, 0);
+        // put p0_new on cart
+        Put1dArrayOnCart(p0_new, p0_cart, false, false, bcs_f, 0);
 
-        // compute delta_p_term = peos_new - peosbar_cart
+        // set delta_p_term = peos_new - p0_new
         for (int lev = 0; lev <= finest_level; ++lev) {
-            MultiFab::Subtract(delta_p_term[lev], peosbar_cart[lev], 0, 0, 1,
-                               0);
+            MultiFab::Subtract(delta_p_term[lev], p0_cart[lev], 0, 0, 1, 0);
         }
     } else {
         // these should have no effect if dpdt_factor <= 0
@@ -910,21 +907,15 @@ void Maestro::AdvanceTimeStepAverage(bool is_initIter) {
 
         // compute delta_p_term = peos_new - p0_new (for RHS of projection)
         if (dpdt_factor > 0.) {
-            // peos_new now holds the thermodynamic p computed from snew(rho h X)
+            // peos now holds "peos_new", the thermodynamic p computed from snew(rho,h,X)
             PfromRhoH(snew, snew, delta_p_term);
 
-            // compute peosbar = Avg(peos_new)
-            Average(delta_p_term, peosbar, 0);
+            // put p0_new on cart
+            Put1dArrayOnCart(p0_new, p0_cart, false, false, bcs_f, 0);
 
-            // no need to compute p0_minus_peosbar since make_w0 is not called after here
-
-            // compute peosbar_cart from peosbar
-            Put1dArrayOnCart(peosbar, peosbar_cart, false, false, bcs_f, 0);
-
-            // compute delta_p_term = peos_new - peosbar_cart
+            // compute delta_p_term = peos_new - p0_new
             for (int lev = 0; lev <= finest_level; ++lev) {
-                MultiFab::Subtract(delta_p_term[lev], peosbar_cart[lev], 0, 0,
-                                   1, 0);
+                MultiFab::Subtract(delta_p_term[lev], p0_cart[lev], 0, 0, 1, 0);
             }
 
             CorrectRHCCforNodalProj(rhcc_for_nodalproj, rho0_new, beta0_nph,

--- a/Source/MaestroAdvanceIrreg.cpp
+++ b/Source/MaestroAdvanceIrreg.cpp
@@ -24,7 +24,6 @@ void Maestro::AdvanceTimeStepIrreg(bool is_initIter) {
     Vector<MultiFab> s2star(finest_level + 1);
     Vector<MultiFab> delta_gamma1_term(finest_level + 1);
     Vector<MultiFab> delta_gamma1(finest_level + 1);
-    Vector<MultiFab> peosbar_cart(finest_level + 1);
     Vector<MultiFab> p0_cart(finest_level + 1);
     Vector<MultiFab> delta_p_term(finest_level + 1);
     Vector<MultiFab> Tcoeff(finest_level + 1);
@@ -116,7 +115,6 @@ void Maestro::AdvanceTimeStepIrreg(bool is_initIter) {
         delta_gamma1_term[lev].define(grids[lev], dmap[lev], 1, 0);
         delta_gamma1[lev].define(grids[lev], dmap[lev], 1, 0);
         p0_cart[lev].define(grids[lev], dmap[lev], 1, 0);
-        peosbar_cart[lev].define(grids[lev], dmap[lev], 1, 0);
         delta_p_term[lev].define(grids[lev], dmap[lev], 1, 0);
         Tcoeff[lev].define(grids[lev], dmap[lev], 1, 1);
         hcoeff1[lev].define(grids[lev], dmap[lev], 1, 1);
@@ -263,6 +261,7 @@ void Maestro::AdvanceTimeStepIrreg(bool is_initIter) {
     // no ghost cells for S_cc_nph
     AverageDown(S_cc_nph, 0, 1);
 
+    // compute p0_minus_peosbar = p0_old - peosbar_old (for making w0) and
     // compute delta_p_term = peos_old - p0_old (for RHS of projections)
     if (dpdt_factor > 0.0) {
         // peos_old (delta_p_term) now holds the thermodynamic p computed from sold(rho,h,X)
@@ -274,13 +273,12 @@ void Maestro::AdvanceTimeStepIrreg(bool is_initIter) {
         // compute p0_minus_peosbar = p0_old - peosbar
         p0_minus_peosbar.copy(p0_old - peosbar);
 
-        // compute peosbar_cart from peosbar
-        Put1dArrayOnCart(peosbar, peosbar_cart, false, false, bcs_f, 0);
+        // put p0_old on cart
+        Put1dArrayOnCart(p0_old, p0_cart, false, false, bcs_f, 0);
 
-        // compute delta_p_term = peos_old - peosbar_cart
+        // compute delta_p_term = peos_old - p0_old
         for (int lev = 0; lev <= finest_level; ++lev) {
-            MultiFab::Subtract(delta_p_term[lev], peosbar_cart[lev], 0, 0, 1,
-                               0);
+            MultiFab::Subtract(delta_p_term[lev], p0_cart[lev], 0, 0, 1, 0);
         }
     } else {
         // these should have no effect if dpdt_factor <= 0
@@ -563,9 +561,10 @@ void Maestro::AdvanceTimeStepIrreg(bool is_initIter) {
     }
     AverageDown(S_cc_nph, 0, 1);
 
-    // and delta_p_term = peos_new - p0_new (for RHS of projection)
+    // compute p0_minus_peosbar = p0_new - peosbar_new (for making w0) and
+    // set delta_p_term = peos_new - p0_new (for RHS of projection)
     if (dpdt_factor > 0.) {
-        // peos_new now holds the thermodynamic p computed from snew(rho,h,X)
+        // peos now holds "peos_new", the thermodynamic p computed from snew(rho,h,X)
         PfromRhoH(snew, snew, delta_p_term);
 
         // compute peosbar = Avg(peos_new)
@@ -574,13 +573,12 @@ void Maestro::AdvanceTimeStepIrreg(bool is_initIter) {
         // compute p0_minus_peosbar = p0_new - peosbar
         p0_minus_peosbar.copy(p0_new - peosbar);
 
-        // compute peosbar_cart from peosbar
-        Put1dArrayOnCart(peosbar, peosbar_cart, false, false, bcs_f, 0);
+        // put p0_new on cart
+        Put1dArrayOnCart(p0_new, p0_cart, false, false, bcs_f, 0);
 
-        // compute delta_p_term = peos_new - peosbar_cart
+        // set delta_p_term = peos_new - p0_new
         for (int lev = 0; lev <= finest_level; ++lev) {
-            MultiFab::Subtract(delta_p_term[lev], peosbar_cart[lev], 0, 0, 1,
-                               0);
+            MultiFab::Subtract(delta_p_term[lev], p0_cart[lev], 0, 0, 1, 0);
         }
     } else {
         // these should have no effect if dpdt_factor <= 0
@@ -895,21 +893,15 @@ void Maestro::AdvanceTimeStepIrreg(bool is_initIter) {
 
         // compute delta_p_term = peos_new - p0_new (for RHS of projection)
         if (dpdt_factor > 0.) {
-            // peos_new now holds the thermodynamic p computed from snew(rho h X)
+            // peos now holds "peos_new", the thermodynamic p computed from snew(rho,h,X)
             PfromRhoH(snew, snew, delta_p_term);
 
-            // compute peosbar = Avg(peos_new)
-            Average(delta_p_term, peosbar, 0);
+            // put p0_new on cart
+            Put1dArrayOnCart(p0_new, p0_cart, false, false, bcs_f, 0);
 
-            // no need to compute p0_minus_peosbar since make_w0 is not called after here
-
-            // compute peosbar_cart from peosbar
-            Put1dArrayOnCart(peosbar, peosbar_cart, false, false, bcs_f, 0);
-
-            // compute delta_p_term = peos_new - peosbar_cart
+            // compute delta_p_term = peos_new - p0_new
             for (int lev = 0; lev <= finest_level; ++lev) {
-                MultiFab::Subtract(delta_p_term[lev], peosbar_cart[lev], 0, 0,
-                                   1, 0);
+                MultiFab::Subtract(delta_p_term[lev], p0_cart[lev], 0, 0, 1, 0);
             }
 
             CorrectRHCCforNodalProj(rhcc_for_nodalproj, rho0_new, beta0_nph,

--- a/Source/MaestroAdvanceSdc.cpp
+++ b/Source/MaestroAdvanceSdc.cpp
@@ -10,43 +10,43 @@ void Maestro::AdvanceTimeStepSDC(bool is_initIter) {
     BL_PROFILE_VAR("Maestro::AdvanceTimeStepSDC()", AdvanceTimeStepSDC);
 
     // cell-centered MultiFabs needed within the AdvanceTimeStep routine
-    Vector<MultiFab>           shat(finest_level+1);
-    Vector<MultiFab>        rhohalf(finest_level+1);
-    Vector<MultiFab>         cphalf(finest_level+1);
-    Vector<MultiFab>         xihalf(finest_level+1);
-    Vector<MultiFab>         macrhs(finest_level+1);
-    Vector<MultiFab>         macphi(finest_level+1);
-    Vector<MultiFab>       S_cc_nph(finest_level+1);
-    Vector<MultiFab>   rho_omegadot(finest_level+1);
-    Vector<MultiFab>       diff_old(finest_level+1);
-    Vector<MultiFab>       diff_new(finest_level+1);
-    Vector<MultiFab>       diff_hat(finest_level+1);
-    Vector<MultiFab> diff_hterm_new(finest_level+1);
-    Vector<MultiFab> diff_hterm_hat(finest_level+1);
-    Vector<MultiFab>       rho_Hnuc(finest_level+1);
-    Vector<MultiFab>       rho_Hext(finest_level+1);
-    Vector<MultiFab>     sdc_source(finest_level+1);
-    Vector<MultiFab>           aofs(finest_level+1);
-    Vector<MultiFab>    intra_rhoh0(finest_level+1);
-    
-    Vector<MultiFab> delta_gamma1_term(finest_level+1);
-    Vector<MultiFab>      delta_gamma1(finest_level+1);
-    Vector<MultiFab>              peos(finest_level+1);
-    Vector<MultiFab>           p0_cart(finest_level+1);
-    Vector<MultiFab>      delta_p_term(finest_level+1);
-    
-    Vector<MultiFab>      Tcoeff1(finest_level+1);
-    Vector<MultiFab>      hcoeff1(finest_level+1);
-    Vector<MultiFab>     Xkcoeff1(finest_level+1);
-    Vector<MultiFab>      pcoeff1(finest_level+1);
-    Vector<MultiFab>      Tcoeff2(finest_level+1);
-    Vector<MultiFab>      hcoeff2(finest_level+1);
-    Vector<MultiFab>     Xkcoeff2(finest_level+1);
-    Vector<MultiFab>      pcoeff2(finest_level+1);
-    Vector<MultiFab>   scal_force(finest_level+1);
-    Vector<MultiFab>    delta_chi(finest_level+1);
-    Vector<MultiFab>       sponge(finest_level+1);
-    Vector<MultiFab>         w0cc(finest_level+1);
+    Vector<MultiFab> shat(finest_level + 1);
+    Vector<MultiFab> rhohalf(finest_level + 1);
+    Vector<MultiFab> cphalf(finest_level + 1);
+    Vector<MultiFab> xihalf(finest_level + 1);
+    Vector<MultiFab> macrhs(finest_level + 1);
+    Vector<MultiFab> macphi(finest_level + 1);
+    Vector<MultiFab> S_cc_nph(finest_level + 1);
+    Vector<MultiFab> rho_omegadot(finest_level + 1);
+    Vector<MultiFab> diff_old(finest_level + 1);
+    Vector<MultiFab> diff_new(finest_level + 1);
+    Vector<MultiFab> diff_hat(finest_level + 1);
+    Vector<MultiFab> diff_hterm_new(finest_level + 1);
+    Vector<MultiFab> diff_hterm_hat(finest_level + 1);
+    Vector<MultiFab> rho_Hnuc(finest_level + 1);
+    Vector<MultiFab> rho_Hext(finest_level + 1);
+    Vector<MultiFab> sdc_source(finest_level + 1);
+    Vector<MultiFab> aofs(finest_level + 1);
+    Vector<MultiFab> intra_rhoh0(finest_level + 1);
+
+    Vector<MultiFab> delta_gamma1_term(finest_level + 1);
+    Vector<MultiFab> delta_gamma1(finest_level + 1);
+    Vector<MultiFab> peos(finest_level + 1);
+    Vector<MultiFab> p0_cart(finest_level + 1);
+    Vector<MultiFab> delta_p_term(finest_level + 1);
+
+    Vector<MultiFab> Tcoeff1(finest_level + 1);
+    Vector<MultiFab> hcoeff1(finest_level + 1);
+    Vector<MultiFab> Xkcoeff1(finest_level + 1);
+    Vector<MultiFab> pcoeff1(finest_level + 1);
+    Vector<MultiFab> Tcoeff2(finest_level + 1);
+    Vector<MultiFab> hcoeff2(finest_level + 1);
+    Vector<MultiFab> Xkcoeff2(finest_level + 1);
+    Vector<MultiFab> pcoeff2(finest_level + 1);
+    Vector<MultiFab> scal_force(finest_level + 1);
+    Vector<MultiFab> delta_chi(finest_level + 1);
+    Vector<MultiFab> sponge(finest_level + 1);
+    Vector<MultiFab> w0cc(finest_level + 1);
 
     // face-centered in the dm-direction (planar only)
     Vector<MultiFab> etarhoflux_dummy(finest_level + 1);
@@ -114,38 +114,38 @@ void Maestro::AdvanceTimeStepSDC(bool is_initIter) {
 
     for (int lev = 0; lev <= finest_level; ++lev) {
         // cell-centered MultiFabs
-        shat        [lev].define(grids[lev], dmap[lev],   Nscal, ng_s);
-        rhohalf     [lev].define(grids[lev], dmap[lev],       1,    1);
-        cphalf      [lev].define(grids[lev], dmap[lev],       1,    1);
-        xihalf      [lev].define(grids[lev], dmap[lev], NumSpec,    1);
-        macrhs      [lev].define(grids[lev], dmap[lev],       1,    0);
-        macphi      [lev].define(grids[lev], dmap[lev],       1,    1);
-        S_cc_nph    [lev].define(grids[lev], dmap[lev],       1,    0);
-        rho_omegadot[lev].define(grids[lev], dmap[lev], NumSpec,    0);
-        diff_old    [lev].define(grids[lev], dmap[lev],       1,    0);
-        diff_new    [lev].define(grids[lev], dmap[lev],       1,    0);
-        diff_hat    [lev].define(grids[lev], dmap[lev],       1,    0);
-        diff_hterm_new[lev].define(grids[lev], dmap[lev],     1,    0);
-        diff_hterm_hat[lev].define(grids[lev], dmap[lev],     1,    0);
-        rho_Hnuc    [lev].define(grids[lev], dmap[lev],       1,    0);
-        rho_Hext    [lev].define(grids[lev], dmap[lev],       1,    0);
-        sdc_source  [lev].define(grids[lev], dmap[lev],   Nscal,    0);
-        aofs        [lev].define(grids[lev], dmap[lev],   Nscal,    0);
-        intra_rhoh0 [lev].define(grids[lev], dmap[lev],       1,    0);
-        delta_gamma1_term[lev].define(grids[lev], dmap[lev],  1,    0);
-        delta_gamma1[lev].define(grids[lev], dmap[lev],       1,    0);
-        peos        [lev].define(grids[lev], dmap[lev],       1,    0);
-        p0_cart     [lev].define(grids[lev], dmap[lev],       1,    0);
-        delta_p_term[lev].define(grids[lev], dmap[lev],       1,    0);
-        Tcoeff1     [lev].define(grids[lev], dmap[lev],       1,    1);
-        hcoeff1     [lev].define(grids[lev], dmap[lev],       1,    1);
-        Xkcoeff1    [lev].define(grids[lev], dmap[lev], NumSpec,    1);
-        pcoeff1     [lev].define(grids[lev], dmap[lev],       1,    1);
-        Tcoeff2     [lev].define(grids[lev], dmap[lev],       1,    1);
-        hcoeff2     [lev].define(grids[lev], dmap[lev],       1,    1);
-        Xkcoeff2    [lev].define(grids[lev], dmap[lev], NumSpec,    1);
-        pcoeff2     [lev].define(grids[lev], dmap[lev],       1,    1);
-        
+        shat[lev].define(grids[lev], dmap[lev], Nscal, ng_s);
+        rhohalf[lev].define(grids[lev], dmap[lev], 1, 1);
+        cphalf[lev].define(grids[lev], dmap[lev], 1, 1);
+        xihalf[lev].define(grids[lev], dmap[lev], NumSpec, 1);
+        macrhs[lev].define(grids[lev], dmap[lev], 1, 0);
+        macphi[lev].define(grids[lev], dmap[lev], 1, 1);
+        S_cc_nph[lev].define(grids[lev], dmap[lev], 1, 0);
+        rho_omegadot[lev].define(grids[lev], dmap[lev], NumSpec, 0);
+        diff_old[lev].define(grids[lev], dmap[lev], 1, 0);
+        diff_new[lev].define(grids[lev], dmap[lev], 1, 0);
+        diff_hat[lev].define(grids[lev], dmap[lev], 1, 0);
+        diff_hterm_new[lev].define(grids[lev], dmap[lev], 1, 0);
+        diff_hterm_hat[lev].define(grids[lev], dmap[lev], 1, 0);
+        rho_Hnuc[lev].define(grids[lev], dmap[lev], 1, 0);
+        rho_Hext[lev].define(grids[lev], dmap[lev], 1, 0);
+        sdc_source[lev].define(grids[lev], dmap[lev], Nscal, 0);
+        aofs[lev].define(grids[lev], dmap[lev], Nscal, 0);
+        intra_rhoh0[lev].define(grids[lev], dmap[lev], 1, 0);
+        delta_gamma1_term[lev].define(grids[lev], dmap[lev], 1, 0);
+        delta_gamma1[lev].define(grids[lev], dmap[lev], 1, 0);
+        peos[lev].define(grids[lev], dmap[lev], 1, 0);
+        p0_cart[lev].define(grids[lev], dmap[lev], 1, 0);
+        delta_p_term[lev].define(grids[lev], dmap[lev], 1, 0);
+        Tcoeff1[lev].define(grids[lev], dmap[lev], 1, 1);
+        hcoeff1[lev].define(grids[lev], dmap[lev], 1, 1);
+        Xkcoeff1[lev].define(grids[lev], dmap[lev], NumSpec, 1);
+        pcoeff1[lev].define(grids[lev], dmap[lev], 1, 1);
+        Tcoeff2[lev].define(grids[lev], dmap[lev], 1, 1);
+        hcoeff2[lev].define(grids[lev], dmap[lev], 1, 1);
+        Xkcoeff2[lev].define(grids[lev], dmap[lev], NumSpec, 1);
+        pcoeff2[lev].define(grids[lev], dmap[lev], 1, 1);
+
         if (ppm_trace_forces == 0) {
             scal_force[lev].define(grids[lev], dmap[lev], Nscal, 1);
         } else {
@@ -276,9 +276,8 @@ void Maestro::AdvanceTimeStepSDC(bool is_initIter) {
     // compute p0_minus_peosbar = p0_old - peosbar_old (for making w0) and
     // compute delta_p_term = peos_old - p0_old (for RHS of projections)
     if (dpdt_factor > 0.0) {
-
         // peos now holds "peos_old", the thermodynamic p computed from sold(rho,h,X)
-        PfromRhoH(sold,sold,peos);
+        PfromRhoH(sold, sold, peos);
 
         // compute peosbar = Avg(peos_old)
         Average(peos, peosbar, 0);
@@ -290,9 +289,9 @@ void Maestro::AdvanceTimeStepSDC(bool is_initIter) {
         Put1dArrayOnCart(p0_old, p0_cart, false, false, bcs_f, 0);
 
         // compute delta_p_term = peos_old - p0_old
-        for (int lev=0; lev<=finest_level; ++lev) {
-            MultiFab::Copy(delta_p_term[lev],peos[lev],0,0,1,0);
-            MultiFab::Subtract(delta_p_term[lev],p0_cart[lev],0,0,1,0);
+        for (int lev = 0; lev <= finest_level; ++lev) {
+            MultiFab::Copy(delta_p_term[lev], peos[lev], 0, 0, 1, 0);
+            MultiFab::Subtract(delta_p_term[lev], p0_cart[lev], 0, 0, 1, 0);
         }
 
     } else {
@@ -702,9 +701,8 @@ void Maestro::AdvanceTimeStepSDC(bool is_initIter) {
             // compute p0_minus_peosbar = p0_new - peosbar_new (for making w0) and
             // increment delta_p_term += peos_new - p0_new (for RHS of projection)
             if (dpdt_factor > 0.) {
-
                 // peos now holds "peos_new", the thermodynamic p computed from snew(rho,h,X)
-                PfromRhoH(snew,snew,peos);
+                PfromRhoH(snew, snew, peos);
 
                 // compute peosbar = Avg(peos_new)
                 Average(peos, peosbar, 0);
@@ -716,9 +714,10 @@ void Maestro::AdvanceTimeStepSDC(bool is_initIter) {
                 Put1dArrayOnCart(p0_new, p0_cart, false, false, bcs_f, 0);
 
                 // increment delta_p_term += peos_new - p0_new
-                for (int lev=0; lev<=finest_level; ++lev) {
-                    MultiFab::Add(delta_p_term[lev],peos[lev],0,0,1,0);
-                    MultiFab::Subtract(delta_p_term[lev],p0_cart[lev],0,0,1,0);
+                for (int lev = 0; lev <= finest_level; ++lev) {
+                    MultiFab::Add(delta_p_term[lev], peos[lev], 0, 0, 1, 0);
+                    MultiFab::Subtract(delta_p_term[lev], p0_cart[lev], 0, 0, 1,
+                                       0);
                 }
 
             } else {
@@ -1184,24 +1183,23 @@ void Maestro::AdvanceTimeStepSDC(bool is_initIter) {
 
         // compute delta_p_term = peos_new - p0_new (for RHS of projection)
         if (dpdt_factor > 0.) {
-
             // peos now holds "peos_new", the thermodynamic p computed from snew(rho,h,X)
-            PfromRhoH(snew,snew,peos);
+            PfromRhoH(snew, snew, peos);
 
             // compute peosbar = Avg(peos_new)
             Average(delta_p_term, peosbar, 0);
 
-                // put p0_new on cart
-                Put1dArrayOnCart(p0_new, p0_cart, false, false, bcs_f, 0);
+            // put p0_new on cart
+            Put1dArrayOnCart(p0_new, p0_cart, false, false, bcs_f, 0);
 
-                // compute delta_p_term = peos_new - p0_new
-                for (int lev=0; lev<=finest_level; ++lev) {
-                    MultiFab::Copy(delta_p_term[lev],peos[lev],0,0,1,0);
-                    MultiFab::Subtract(delta_p_term[lev],p0_cart[lev],0,0,1,0);
-                }
-            
-                CorrectRHCCforNodalProj(rhcc_for_nodalproj,rho0_new,beta0_nph,gamma1bar_new,
-                                        p0_new,delta_p_term);
+            // compute delta_p_term = peos_new - p0_new
+            for (int lev = 0; lev <= finest_level; ++lev) {
+                MultiFab::Copy(delta_p_term[lev], peos[lev], 0, 0, 1, 0);
+                MultiFab::Subtract(delta_p_term[lev], p0_cart[lev], 0, 0, 1, 0);
+            }
+
+            CorrectRHCCforNodalProj(rhcc_for_nodalproj, rho0_new, beta0_nph,
+                                    gamma1bar_new, p0_new, delta_p_term);
         }
     }
 

--- a/Source/MaestroAdvanceSdc.cpp
+++ b/Source/MaestroAdvanceSdc.cpp
@@ -478,7 +478,7 @@ void Maestro::AdvanceTimeStepSDC(bool is_initIter) {
                           sold[lev], 0, 0, Nscal, 0);
         MultiFab::Subtract(aofs[lev], intra[lev], 0, 0, Nscal, 0);
     }
-    
+
     //////////////////////////////////////////////////////////////////////////////
     // STEP 2B (optional) -- compute diffusive flux divergence
     //////////////////////////////////////////////////////////////////////////////
@@ -486,7 +486,7 @@ void Maestro::AdvanceTimeStepSDC(bool is_initIter) {
     if (maestro_verbose >= 1) {
         Print() << "<<< STEP 2B : compute diffusive flux div >>>" << std::endl;
     }
-    
+
     if (use_thermal_diffusion) {
         // 1 = predictor, 2 = corrector
         ThermalConductSDC(1, sold, shat, snew, p0_old, p0_new, hcoeff1,
@@ -496,7 +496,7 @@ void Maestro::AdvanceTimeStepSDC(bool is_initIter) {
         MakeExplicitThermal(diff_hat, shat, Tcoeff1, hcoeff1, Xkcoeff1, pcoeff1,
                             p0_new, temp_diffusion_formulation);
     }
-    
+
     //////////////////////////////////////////////////////////////////////////////
     // STEP 2C -- advance thermodynamic variables
     //////////////////////////////////////////////////////////////////////////////
@@ -514,7 +514,7 @@ void Maestro::AdvanceTimeStepSDC(bool is_initIter) {
                           diff_hat[lev], 0, RhoH, 1, 0);
         MultiFab::Add(sdc_source[lev], aofs[lev], RhoH, RhoH, 1, 0);
     }
-    
+
     // wallclock time
     Real start_total_react = ParallelDescriptor::second();
 
@@ -711,7 +711,8 @@ void Maestro::AdvanceTimeStepSDC(bool is_initIter) {
 
                 // set delta_p_term = peos_new - p0_new
                 for (int lev = 0; lev <= finest_level; ++lev) {
-                    MultiFab::Subtract(delta_p_term[lev], p0_cart[lev], 0, 0, 1, 0);
+                    MultiFab::Subtract(delta_p_term[lev], p0_cart[lev], 0, 0, 1,
+                                       0);
                 }
 
             } else {
@@ -1107,7 +1108,7 @@ void Maestro::AdvanceTimeStepSDC(bool is_initIter) {
             Makew0(w0_old, w0_force_dummy, Sbar, rho0_new, rho0_new, p0_new,
                    p0_new, gamma1bar_new, gamma1bar_new, p0_minus_peosbar, dt,
                    dtold, is_predictor);
-            
+
             Put1dArrayOnCart(w0, w0_cart, true, true, bcs_u, 0, 1);
         }
     }
@@ -1133,8 +1134,10 @@ void Maestro::AdvanceTimeStepSDC(bool is_initIter) {
     if (spherical && evolve_base_state && split_projection) {
         // subtract w0 from uold and unew for nodal projection
         for (int lev = 0; lev <= finest_level; ++lev) {
-            MultiFab::Subtract(uold[lev], w0_cart[lev], 0, 0, AMREX_SPACEDIM, 0);
-            MultiFab::Subtract(unew[lev], w0_cart[lev], 0, 0, AMREX_SPACEDIM, 0);
+            MultiFab::Subtract(uold[lev], w0_cart[lev], 0, 0, AMREX_SPACEDIM,
+                               0);
+            MultiFab::Subtract(unew[lev], w0_cart[lev], 0, 0, AMREX_SPACEDIM,
+                               0);
         }
     }
 

--- a/Source/MaestroAdvanceSdc.cpp
+++ b/Source/MaestroAdvanceSdc.cpp
@@ -314,7 +314,7 @@ void Maestro::AdvanceTimeStepSDC(bool is_initIter) {
                    p0_old, gamma1bar_old, gamma1bar_old, p0_minus_peosbar, dt,
                    dtold, is_predictor);
 
-	    Put1dArrayOnCart(w0, w0_cart, true, true, bcs_u, 0, 1);
+            Put1dArrayOnCart(w0, w0_cart, true, true, bcs_u, 0, 1);
 #if (AMREX_SPACEDIM == 3)
             if (spherical) {
                 // put w0 on Cartesian edges
@@ -743,7 +743,7 @@ void Maestro::AdvanceTimeStepSDC(bool is_initIter) {
                            p0_old, p0_new, gamma1bar_old, gamma1bar_new,
                            p0_minus_peosbar, dt, dtold, is_predictor);
 
-		    Put1dArrayOnCart(w0, w0_cart, true, true, bcs_u, 0, 1);
+                    Put1dArrayOnCart(w0, w0_cart, true, true, bcs_u, 0, 1);
 #if (AMREX_SPACEDIM == 3)
                     if (spherical) {
                         // put w0 on Cartesian edges
@@ -1113,7 +1113,7 @@ void Maestro::AdvanceTimeStepSDC(bool is_initIter) {
                    p0_new, gamma1bar_new, gamma1bar_new, p0_minus_peosbar, dt,
                    dtold, is_predictor);
             
-	    Put1dArrayOnCart(w0, w0_cart, true, true, bcs_u, 0, 1);
+            Put1dArrayOnCart(w0, w0_cart, true, true, bcs_u, 0, 1);
         }
     }
 

--- a/Source/MaestroAdvanceSdc.cpp
+++ b/Source/MaestroAdvanceSdc.cpp
@@ -698,7 +698,7 @@ void Maestro::AdvanceTimeStepSDC(bool is_initIter) {
             AverageDown(S_cc_nph, 0, 1);
 
             // compute p0_minus_peosbar = p0_new - peosbar_new (for making w0) and
-            // increment delta_p_term += peos_new - p0_new (for RHS of projection)
+            // set delta_p_term = peos_new - p0_new (for RHS of projection)
             if (dpdt_factor > 0.) {
                 // peos now holds "peos_new", the thermodynamic p computed from snew(rho,h,X)
                 PfromRhoH(snew, snew, peos);
@@ -712,11 +712,10 @@ void Maestro::AdvanceTimeStepSDC(bool is_initIter) {
                 // put p0_new on cart
                 Put1dArrayOnCart(p0_new, p0_cart, false, false, bcs_f, 0);
 
-                // increment delta_p_term += peos_new - p0_new
+                // set delta_p_term = peos_new - p0_new
                 for (int lev = 0; lev <= finest_level; ++lev) {
-                    MultiFab::Add(delta_p_term[lev], peos[lev], 0, 0, 1, 0);
-                    MultiFab::Subtract(delta_p_term[lev], p0_cart[lev], 0, 0, 1,
-                                       0);
+                    MultiFab::Copy(delta_p_term[lev], peos[lev], 0, 0, 1, 0);
+                    MultiFab::Subtract(delta_p_term[lev], p0_cart[lev], 0, 0, 1, 0);
                 }
 
             } else {
@@ -1182,9 +1181,6 @@ void Maestro::AdvanceTimeStepSDC(bool is_initIter) {
         if (dpdt_factor > 0.) {
             // peos now holds "peos_new", the thermodynamic p computed from snew(rho,h,X)
             PfromRhoH(snew, snew, peos);
-
-            // compute peosbar = Avg(peos_new)
-            Average(delta_p_term, peosbar, 0);
 
             // put p0_new on cart
             Put1dArrayOnCart(p0_new, p0_cart, false, false, bcs_f, 0);

--- a/Source/MaestroAdvanceSdc.cpp
+++ b/Source/MaestroAdvanceSdc.cpp
@@ -33,8 +33,7 @@ Maestro::AdvanceTimeStepSDC (bool is_initIter) {
     
     Vector<MultiFab> delta_gamma1_term(finest_level+1);
     Vector<MultiFab>      delta_gamma1(finest_level+1);
-    Vector<MultiFab>          peos_old(finest_level+1);
-    Vector<MultiFab>      peosbar_cart(finest_level+1);
+    Vector<MultiFab>              peos(finest_level+1);
     Vector<MultiFab>           p0_cart(finest_level+1);
     Vector<MultiFab>      delta_p_term(finest_level+1);
     
@@ -126,8 +125,7 @@ Maestro::AdvanceTimeStepSDC (bool is_initIter) {
         intra_rhoh0 [lev].define(grids[lev], dmap[lev],       1,    0);
         delta_gamma1_term[lev].define(grids[lev], dmap[lev],  1,    0);
         delta_gamma1[lev].define(grids[lev], dmap[lev],       1,    0);
-        peos_old    [lev].define(grids[lev], dmap[lev],       1,    0);
-        peosbar_cart[lev].define(grids[lev], dmap[lev],       1,    0);
+        peos        [lev].define(grids[lev], dmap[lev],       1,    0);
         p0_cart     [lev].define(grids[lev], dmap[lev],       1,    0);
         delta_p_term[lev].define(grids[lev], dmap[lev],       1,    0);
         Tcoeff1     [lev].define(grids[lev], dmap[lev],       1,    1);
@@ -243,25 +241,28 @@ Maestro::AdvanceTimeStepSDC (bool is_initIter) {
     // no ghost cells for S_cc_nph
     AverageDown(S_cc_nph, 0, 1);
 
-    // compute p0_minus_peosbar = p0_old - peosbar (for making w0) and
+    // compute p0_minus_peosbar = p0_old - peosbar_old (for making w0) and
     // compute delta_p_term = peos_old - p0_old (for RHS of projections)
     if (dpdt_factor > 0.0) {
-        // peos_old (delta_p_term) now holds the thermodynamic p computed from sold(rho,h,X)
-        PfromRhoH(sold,sold,peos_old);
+
+        // peos now holds "peos_old", the thermodynamic p computed from sold(rho,h,X)
+        PfromRhoH(sold,sold,peos);
 
         // compute peosbar = Avg(peos_old)
-        Average(delta_p_term, peosbar, 0);
+        Average(peos, peosbar, 0);
 
         // compute p0_minus_peosbar = p0_old - peosbar
         p0_minus_peosbar.copy(p0_old - peosbar);
 
-        // compute peosbar_cart from peosbar
-        Put1dArrayOnCart(peosbar, peosbar_cart, false, false, bcs_f, 0);
+        // put p0_old on cart
+        Put1dArrayOnCart(p0_old, p0_cart, false, false, bcs_f, 0);
 
-        // compute delta_p_term = peos_old - peosbar_cart
+        // compute delta_p_term = peos_old - p0_old
         for (int lev=0; lev<=finest_level; ++lev) {
-            MultiFab::LinComb(delta_p_term[lev],1.0,peos_old[lev],0,-1.0,peosbar_cart[lev],0,0,1,0);
+            MultiFab::Copy(delta_p_term[lev],peos[lev],0,0,1,0);
+            MultiFab::Subtract(delta_p_term[lev],p0_cart[lev],0,0,1,0);
         }
+
     } else {
         // these should have no effect if dpdt_factor <= 0
         p0_minus_peosbar.setVal(0.0);
@@ -664,33 +665,28 @@ Maestro::AdvanceTimeStepSDC (bool is_initIter) {
             }
             AverageDown(S_cc_nph,0,1);
 
-            // and delta_p_term = peos_new - p0_new (for RHS of projection)
+            // compute p0_minus_peosbar = p0_new - peosbar_new (for making w0) and
+            // increment delta_p_term += peos_new - p0_new (for RHS of projection)
             if (dpdt_factor > 0.) {
-                // peos_new now holds the thermodynamic p computed from snew(rho,h,X)
-                PfromRhoH(snew,snew,delta_p_term);
 
-                // compute peos_nph = (1/2)*(peos_old+peos_new)
-                for (int lev=0; lev<=finest_level; ++lev) {
-                    MultiFab::Add(delta_p_term[lev],peos_old[lev],0,0,1,0);
-                    delta_p_term[lev].mult(0.5);
-                }
-                
+                // peos now holds "peos_new", the thermodynamic p computed from snew(rho,h,X)
+                PfromRhoH(snew,snew,peos);
+
                 // compute peosbar = Avg(peos_new)
-                Average(delta_p_term, peosbar, 0);
+                Average(peos, peosbar, 0);
 
-                // compute p0_nph
-                // p0_nph.copy(0.5*(p0_old + p0_new));
-                
-                // compute p0_minus_peosbar = p0_nph - peosbar
-                p0_minus_peosbar.copy(0.5*(p0_old + p0_new) - peosbar);
-            
-                // compute peosbar_cart from peosbar
-                Put1dArrayOnCart(peosbar, peosbar_cart, false, false, bcs_f, 0);
-                
-                // compute delta_p_term = peos_new - peosbar_cart
+                // compute p0_minus_peosbar = p0_new - peosbar
+                p0_minus_peosbar.copy(p0_new - peosbar);
+
+                // put p0_new on cart
+                Put1dArrayOnCart(p0_new, p0_cart, false, false, bcs_f, 0);
+
+                // increment delta_p_term += peos_new - p0_new
                 for (int lev=0; lev<=finest_level; ++lev) {
-                    MultiFab::Subtract(delta_p_term[lev],peosbar_cart[lev],0,0,1,0);
+                    MultiFab::Add(delta_p_term[lev],peos[lev],0,0,1,0);
+                    MultiFab::Subtract(delta_p_term[lev],p0_cart[lev],0,0,1,0);
                 }
+
             } else {
                 // these should have no effect if dpdt_factor <= 0
                 p0_minus_peosbar.setVal(0.);
@@ -1141,24 +1137,24 @@ Maestro::AdvanceTimeStepSDC (bool is_initIter) {
 
         // compute delta_p_term = peos_new - p0_new (for RHS of projection)
         if (dpdt_factor > 0.) {
-            // peos_new now holds the thermodynamic p computed from snew(rho h X)
-            PfromRhoH(snew,snew,delta_p_term);
+
+            // peos now holds "peos_new", the thermodynamic p computed from snew(rho,h,X)
+            PfromRhoH(snew,snew,peos);
 
             // compute peosbar = Avg(peos_new)
             Average(delta_p_term, peosbar, 0);
 
-            // no need to compute p0_minus_peosbar since make_w0 is not called after here
+                // put p0_new on cart
+                Put1dArrayOnCart(p0_new, p0_cart, false, false, bcs_f, 0);
 
-            // compute peosbar_cart from peosbar
-            Put1dArrayOnCart(peosbar, peosbar_cart, false, false, bcs_f, 0);
-
-            // compute delta_p_term = peos_new - peosbar_cart
-            for (int lev=0; lev<=finest_level; ++lev) {
-                MultiFab::Subtract(delta_p_term[lev],peosbar_cart[lev],0,0,1,0);
-            }
-
-            CorrectRHCCforNodalProj(rhcc_for_nodalproj,rho0_new,beta0_nph,gamma1bar_new,
-                                    p0_new,delta_p_term);
+                // compute delta_p_term = peos_new - p0_new
+                for (int lev=0; lev<=finest_level; ++lev) {
+                    MultiFab::Copy(delta_p_term[lev],peos[lev],0,0,1,0);
+                    MultiFab::Subtract(delta_p_term[lev],p0_cart[lev],0,0,1,0);
+                }
+            
+                CorrectRHCCforNodalProj(rhcc_for_nodalproj,rho0_new,beta0_nph,gamma1bar_new,
+                                        p0_new,delta_p_term);
         }
     }
 

--- a/Source/MaestroEnthalpyAdvance.cpp
+++ b/Source/MaestroEnthalpyAdvance.cpp
@@ -426,7 +426,7 @@ void Maestro::EnthalpyAdvanceSDC(
 
         ModifyScalForce(scal_force, scalold, umac, rhoh0_edge_old,
                         rhoh0_old_cart, RhoH, bcs_s, 0);
-        
+
     } else if (enthalpy_pred_type == predict_h ||
                enthalpy_pred_type == predict_rhoh) {
         // make force for (rho h)

--- a/Source/MaestroEnthalpyAdvance.cpp
+++ b/Source/MaestroEnthalpyAdvance.cpp
@@ -398,12 +398,14 @@ void Maestro::EnthalpyAdvanceSDC(
     //////////////////////////////////
 
     for (int lev = 0; lev <= finest_level; ++lev) {
-        scal_force[lev].setVal(0., RhoH, 1, 1);
+        scal_force[lev].setVal(0.);
     }
 
     Vector<MultiFab> rhoh0_old_cart(finest_level + 1);
     for (int lev = 0; lev <= finest_level; ++lev) {
         rhoh0_old_cart[lev].define(grids[lev], dmap[lev], 1, 1);
+	// needed to avoid NaNs in filling corner ghost cells with 2 physical boundaries
+	rhoh0_old_cart[lev].setVal(0.);
     }
 
     /////////////////////////////////////////////////////////////////
@@ -424,6 +426,7 @@ void Maestro::EnthalpyAdvanceSDC(
 
         ModifyScalForce(scal_force, scalold, umac, rhoh0_edge_old,
                         rhoh0_old_cart, RhoH, bcs_s, 0);
+	
     } else if (enthalpy_pred_type == predict_h ||
                enthalpy_pred_type == predict_rhoh) {
         // make force for (rho h)

--- a/Source/MaestroEnthalpyAdvance.cpp
+++ b/Source/MaestroEnthalpyAdvance.cpp
@@ -404,8 +404,8 @@ void Maestro::EnthalpyAdvanceSDC(
     Vector<MultiFab> rhoh0_old_cart(finest_level + 1);
     for (int lev = 0; lev <= finest_level; ++lev) {
         rhoh0_old_cart[lev].define(grids[lev], dmap[lev], 1, 1);
-	// needed to avoid NaNs in filling corner ghost cells with 2 physical boundaries
-	rhoh0_old_cart[lev].setVal(0.);
+        // needed to avoid NaNs in filling corner ghost cells with 2 physical boundaries
+        rhoh0_old_cart[lev].setVal(0.);
     }
 
     /////////////////////////////////////////////////////////////////
@@ -426,7 +426,7 @@ void Maestro::EnthalpyAdvanceSDC(
 
         ModifyScalForce(scal_force, scalold, umac, rhoh0_edge_old,
                         rhoh0_old_cart, RhoH, bcs_s, 0);
-	
+        
     } else if (enthalpy_pred_type == predict_h ||
                enthalpy_pred_type == predict_rhoh) {
         // make force for (rho h)

--- a/Source/MaestroMakeS.cpp
+++ b/Source/MaestroMakeS.cpp
@@ -383,12 +383,23 @@ Maestro::CorrectRHCCforNodalProj(Vector<MultiFab>& rhcc,
             const Array4<const Real> p0_arr = p0_cart[lev].array(mfi);
             const Array4<const Real> rho0_arr = rho0_cart[lev].array(mfi);
 
-            AMREX_PARALLEL_FOR_3D(tileBox, i, j, k, {
-                Real correction_factor = rho0_arr(i,j,k) > base_cutoff_density_loc ? 
-                    beta0_arr(i,j,k) * dpdt_factor_loc / (gamma1bar_arr(i,j,k) * p0_arr(i,j,k)) / dt_loc : 0.0;
+            if (spherical == 1) {
+                AMREX_PARALLEL_FOR_3D(tileBox, i, j, k, {
+                    Real correction_factor = rho0_arr(i,j,k) > base_cutoff_density_loc ?
+                        beta0_arr(i,j,k) * dpdt_factor_loc / (gamma1bar_arr(i,j,k) * p0_arr(i,j,k)) / dt_loc : 0.0;
 
-                correction_arr(i,j,k) = correction_factor * delta_p_arr(i,j,k);
-            });
+                    correction_arr(i,j,k) = correction_factor * delta_p_arr(i,j,k);
+                });
+            } else {
+                AMREX_PARALLEL_FOR_3D(tileBox, i, j, k, {
+                    int r = (AMREX_SPACEDIM == 2) ? j : k;
+                    Real correction_factor = (r < base_geom.base_cutoff_density_coord(lev)) ?
+                        beta0_arr(i,j,k) * dpdt_factor_loc / (gamma1bar_arr(i,j,k) * p0_arr(i,j,k)) / dt_loc : 0.0;
+
+                    correction_arr(i,j,k) = correction_factor * delta_p_arr(i,j,k);
+                });
+
+            }
         }
     }
 
@@ -489,14 +500,27 @@ Maestro::MakeRHCCforMacProj (Vector<MultiFab>& rhcc,
                     });
                 } 
 
-                AMREX_PARALLEL_FOR_3D(tileBox, i, j, k, {
-                    if (rho0_arr(i,j,k) > base_cutoff_density_loc) {
-                        delta_chi_arr(i,j,k) += dpdt_factor_loc * delta_p_arr(i,j,k) / 
-                            (dt_loc*gamma1bar_arr(i,j,k)*p0_arr(i,j,k));
-                        rhcc_arr(i,j,k) += beta0_arr(i,j,k) * delta_chi_arr(i,j,k);
-                    }
-                });
-            } 
-        }
-    }
+                if (spherical == 1) {
+                    AMREX_PARALLEL_FOR_3D(tileBox, i, j, k, {
+                        if (rho0_arr(i,j,k) > base_cutoff_density_loc) {
+                            delta_chi_arr(i,j,k) += dpdt_factor_loc * delta_p_arr(i,j,k) / 
+                                (dt_loc*gamma1bar_arr(i,j,k)*p0_arr(i,j,k));
+                            rhcc_arr(i,j,k) += beta0_arr(i,j,k) * delta_chi_arr(i,j,k);
+                        }
+                    });
+                } else {
+                    AMREX_PARALLEL_FOR_3D(tileBox, i, j, k, {
+
+                        int r = (AMREX_SPACEDIM == 2) ? j : k;
+
+                        if (r < base_geom.base_cutoff_density_coord(lev)) {
+                            delta_chi_arr(i,j,k) += dpdt_factor_loc * delta_p_arr(i,j,k) / 
+                                (dt_loc*gamma1bar_arr(i,j,k)*p0_arr(i,j,k));
+                            rhcc_arr(i,j,k) += beta0_arr(i,j,k) * delta_chi_arr(i,j,k);
+                        }
+                    });
+                } // if spherical or planar
+            } // if (dpdt_factor > 0)
+        } // end MFIter
+    } // end loop over levels
 }

--- a/Source/MaestroMakeS.cpp
+++ b/Source/MaestroMakeS.cpp
@@ -410,20 +410,29 @@ void Maestro::CorrectRHCCforNodalProj(Vector<MultiFab>& rhcc,
 
             if (spherical == 1) {
                 AMREX_PARALLEL_FOR_3D(tileBox, i, j, k, {
-                    Real correction_factor = rho0_arr(i,j,k) > base_cutoff_density_loc ?
-                        beta0_arr(i,j,k) * dpdt_factor_loc / (gamma1bar_arr(i,j,k) * p0_arr(i,j,k)) / dt_loc : 0.0;
+                    Real correction_factor =
+                        rho0_arr(i, j, k) > base_cutoff_density_loc
+                            ? beta0_arr(i, j, k) * dpdt_factor_loc /
+                                  (gamma1bar_arr(i, j, k) * p0_arr(i, j, k)) /
+                                  dt_loc
+                            : 0.0;
 
-                    correction_arr(i,j,k) = correction_factor * delta_p_arr(i,j,k);
+                    correction_arr(i, j, k) =
+                        correction_factor * delta_p_arr(i, j, k);
                 });
             } else {
                 AMREX_PARALLEL_FOR_3D(tileBox, i, j, k, {
                     int r = (AMREX_SPACEDIM == 2) ? j : k;
-                    Real correction_factor = (r < base_geom.base_cutoff_density_coord(lev)) ?
-                        beta0_arr(i,j,k) * dpdt_factor_loc / (gamma1bar_arr(i,j,k) * p0_arr(i,j,k)) / dt_loc : 0.0;
+                    Real correction_factor =
+                        (r < base_geom.base_cutoff_density_coord(lev))
+                            ? beta0_arr(i, j, k) * dpdt_factor_loc /
+                                  (gamma1bar_arr(i, j, k) * p0_arr(i, j, k)) /
+                                  dt_loc
+                            : 0.0;
 
-                    correction_arr(i,j,k) = correction_factor * delta_p_arr(i,j,k);
+                    correction_arr(i, j, k) =
+                        correction_factor * delta_p_arr(i, j, k);
                 });
-
             }
         }
     }
@@ -522,25 +531,30 @@ void Maestro::MakeRHCCforMacProj(
 
                 if (spherical == 1) {
                     AMREX_PARALLEL_FOR_3D(tileBox, i, j, k, {
-                        if (rho0_arr(i,j,k) > base_cutoff_density_loc) {
-                            delta_chi_arr(i,j,k) += dpdt_factor_loc * delta_p_arr(i,j,k) / 
-                                (dt_loc*gamma1bar_arr(i,j,k)*p0_arr(i,j,k));
-                            rhcc_arr(i,j,k) += beta0_arr(i,j,k) * delta_chi_arr(i,j,k);
+                        if (rho0_arr(i, j, k) > base_cutoff_density_loc) {
+                            delta_chi_arr(i, j, k) +=
+                                dpdt_factor_loc * delta_p_arr(i, j, k) /
+                                (dt_loc * gamma1bar_arr(i, j, k) *
+                                 p0_arr(i, j, k));
+                            rhcc_arr(i, j, k) +=
+                                beta0_arr(i, j, k) * delta_chi_arr(i, j, k);
                         }
                     });
                 } else {
                     AMREX_PARALLEL_FOR_3D(tileBox, i, j, k, {
-
                         int r = (AMREX_SPACEDIM == 2) ? j : k;
 
                         if (r < base_geom.base_cutoff_density_coord(lev)) {
-                            delta_chi_arr(i,j,k) += dpdt_factor_loc * delta_p_arr(i,j,k) / 
-                                (dt_loc*gamma1bar_arr(i,j,k)*p0_arr(i,j,k));
-                            rhcc_arr(i,j,k) += beta0_arr(i,j,k) * delta_chi_arr(i,j,k);
+                            delta_chi_arr(i, j, k) +=
+                                dpdt_factor_loc * delta_p_arr(i, j, k) /
+                                (dt_loc * gamma1bar_arr(i, j, k) *
+                                 p0_arr(i, j, k));
+                            rhcc_arr(i, j, k) +=
+                                beta0_arr(i, j, k) * delta_chi_arr(i, j, k);
                         }
                     });
-                } // if spherical or planar
-            } // if (dpdt_factor > 0)
-        } // end MFIter
-    } // end loop over levels
+                }  // if spherical or planar
+            }      // if (dpdt_factor > 0)
+        }          // end MFIter
+    }              // end loop over levels
 }


### PR DESCRIPTION
Fixed the smallscale SDC implementation.  Merging this PR will completely address #205 
    
For both SDC and Strang, the logic for including the dpdt terms was wrong; it was looking at rho0 instead of the cutoff coordinates (rho0 is zero for smallscale)
    
Also, updated the iterative logic in MaestroAdvanceSdc.cpp to use the latest dpdt algorithmic methodology, where delta_p_term is incremented by (p0_new - peos_new) instead of reset to this value after each iteration