### PR TITLE
By default, run until stop_time, rather than for 1 time step

### DIFF
--- a/Source/MaestroEvolve.cpp
+++ b/Source/MaestroEvolve.cpp
@@ -19,7 +19,9 @@ void Maestro::Evolve() {
     // index for diag array buffer
     int diag_index = 0;
 
-    for (istep = start_step; istep <= max_step && t_old < stop_time; ++istep) {
+    for (istep = start_step; ((istep <= max_step || max_step < 0) &&
+			     (t_old < stop_time  || stop_time < 0.0)); ++istep)
+    {
         // check to see if we need to regrid, then regrid
         if (max_level > 0 && regrid_int > 0 && (istep - 1) % regrid_int == 0 &&
             istep != 1) {
@@ -65,7 +67,7 @@ void Maestro::Evolve() {
             }
 
             if (stop_time >= 0. && t_old + dt > stop_time) {
-                dt = amrex::min(dt, stop_time - t_old);
+                dt = std::min(dt, stop_time - t_old);
                 Print() << "Stop time limits dt = " << dt << std::endl;
             }
 

--- a/Source/MaestroEvolve.cpp
+++ b/Source/MaestroEvolve.cpp
@@ -67,7 +67,7 @@ void Maestro::Evolve() {
             }
 
             if (stop_time >= 0. && t_old + dt > stop_time) {
-                dt = std::min(dt, stop_time - t_old);
+                dt = amrex::min(dt, stop_time - t_old);
                 Print() << "Stop time limits dt = " << dt << std::endl;
             }
 

--- a/Source/param/_cpp_parameters
+++ b/Source/param/_cpp_parameters
@@ -48,10 +48,10 @@ print_init_hse_diag                 bool        false          y
 #-----------------------------------------------------------------------------
 
 # simulation stop time
-stop_time                           Real        -1.0
+stop_time                           Real        -1.0           y
 
 # Maximum number of steps in the simulation.
-max_step                            int         1
+max_step                            int         -1             y
 
 # CFL factor to use in the computation of the advection timestep constraint
 cfl                                 Real              0.5        y

--- a/Source/param/meth_params.template
+++ b/Source/param/meth_params.template
@@ -56,6 +56,10 @@ contains
 
     @@set_maestro_params@@
 
+    if ((max_step < 0) .AND. (stop_time < 0.0)) then
+       call amrex_error("must supply either a positive stop_time or positive max_step")
+    end if
+
     if (base_cutoff_density .eq. -1.d0) then
        call amrex_error("must supply base_cutoff_density")
     end if

--- a/Source/param_includes/maestro_params.H
+++ b/Source/param_includes/maestro_params.H
@@ -164,6 +164,6 @@ extern AMREX_GPU_MANAGED amrex::Real eps_hg;
 extern AMREX_GPU_MANAGED amrex::Real eps_hg_max;
 extern AMREX_GPU_MANAGED amrex::Real hg_level_factor;
 extern AMREX_GPU_MANAGED amrex::Real eps_hg_bottom;
-};  // namespace maestro
+};
 
 #endif

--- a/Source/param_includes/maestro_queries.H
+++ b/Source/param_includes/maestro_queries.H
@@ -21,7 +21,7 @@ pp.query("print_init_hse_diag", maestro::print_init_hse_diag);
 maestro::stop_time = -1.0;
 pp.query("stop_time", maestro::stop_time);
 
-maestro::max_step = 1;
+maestro::max_step = -1;
 pp.query("max_step", maestro::max_step);
 
 maestro::cfl = 0.5;
@@ -481,3 +481,4 @@ pp.query("hg_level_factor", maestro::hg_level_factor);
 
 maestro::eps_hg_bottom = 1.e-4;
 pp.query("eps_hg_bottom", maestro::eps_hg_bottom);
+

--- a/Source/param_includes/meth_params.F90
+++ b/Source/param_includes/meth_params.F90
@@ -41,6 +41,8 @@ module meth_params_module
   character (len=:), allocatable, save :: model_file
   logical          , allocatable, save :: perturb_model
   logical          , allocatable, save :: print_init_hse_diag
+  double precision , allocatable, save :: stop_time
+  integer          , allocatable, save :: max_step
   double precision , allocatable, save :: cfl
   logical          , allocatable, save :: use_soundspeed_firstdt
   logical          , allocatable, save :: use_divu_firstdt
@@ -104,6 +106,8 @@ module meth_params_module
 
   attributes(managed) :: perturb_model
   attributes(managed) :: print_init_hse_diag
+  attributes(managed) :: stop_time
+  attributes(managed) :: max_step
   attributes(managed) :: cfl
   attributes(managed) :: use_soundspeed_firstdt
   attributes(managed) :: use_divu_firstdt
@@ -191,6 +195,10 @@ contains
     perturb_model = .false.;
     allocate(print_init_hse_diag)
     print_init_hse_diag = .false.;
+    allocate(stop_time)
+    stop_time = -1.0d0;
+    allocate(max_step)
+    max_step = -1;
     allocate(cfl)
     cfl = 0.5d0;
     allocate(use_soundspeed_firstdt)
@@ -311,6 +319,8 @@ contains
     call pp%query("model_file", model_file)
     call pp%query("perturb_model", perturb_model)
     call pp%query("print_init_hse_diag", print_init_hse_diag)
+    call pp%query("stop_time", stop_time)
+    call pp%query("max_step", max_step)
     call pp%query("cfl", cfl)
     call pp%query("use_soundspeed_firstdt", use_soundspeed_firstdt)
     call pp%query("use_divu_firstdt", use_divu_firstdt)
@@ -372,6 +382,10 @@ contains
 
 
 
+    if ((max_step < 0) .AND. (stop_time < 0.0)) then
+       call amrex_error("must supply either a positive stop_time or positive max_step")
+    end if
+
     if (base_cutoff_density .eq. -1.d0) then
        call amrex_error("must supply base_cutoff_density")
     end if
@@ -409,6 +423,12 @@ contains
     end if
     if (allocated(print_init_hse_diag)) then
         deallocate(print_init_hse_diag)
+    end if
+    if (allocated(stop_time)) then
+        deallocate(stop_time)
+    end if
+    if (allocated(max_step)) then
+        deallocate(max_step)
     end if
     if (allocated(cfl)) then
         deallocate(cfl)

--- a/Source/param_includes/state_indices.H
+++ b/Source/param_includes/state_indices.H
@@ -2,14 +2,14 @@
 #define _state_indices_H_
 #include <network_properties.H>
 
-constexpr int Nscal = 4 + NumSpec + NumAux;
+  constexpr int Nscal = 4 + NumSpec + NumAux;
 
-// scalars
-constexpr int Rho = 0;
-constexpr int RhoH = 1;
-constexpr int Temp = 2;
-constexpr int Pi = 3;
-constexpr int FirstSpec = 4;
-constexpr int FirstAux = 4 + NumSpec;
+   // scalars
+  constexpr int Rho = 0;
+  constexpr int RhoH = 1;
+  constexpr int Temp = 2;
+  constexpr int Pi = 3;
+  constexpr int FirstSpec = 4;
+  constexpr int FirstAux = 4 + NumSpec;
 
 #endif


### PR DESCRIPTION
This PR changes MAESTROeX such that by default we assume the `max_step` is -1. This will cause the timestep loop to only break if the `stop_time` is reached, whereas before, we would just stop after 1 time step. This is what Castro does and I think it makes the most sense to do rather than always having to set `max_step` to some arbitrarily high number. 

