### PR TITLE
Remove dependence on AMReX C_CellMG which is now removed

### DIFF
--- a/Exec/Make.Maestro
+++ b/Exec/Make.Maestro
@@ -97,7 +97,7 @@ endif
 # directories into VPATH_LOCATIONS and INCLUDE_LOCATIONS for us, so we
 # don't need to do it here
 
-Pdirs 	:= Base Boundary AmrCore LinearSolvers/C_CellMG LinearSolvers/MLMG
+Pdirs 	:= Base Boundary AmrCore LinearSolvers/MLMG
 
 Bpack	+= $(foreach dir, $(Pdirs), $(AMREX_HOME)/Src/$(dir)/Make.package)
 


### PR DESCRIPTION
This was removed in AMReX-Codes/amrex#1238.