### PR TITLE
Fancy Bottom Solver Control

### DIFF
--- a/Source/MaestroMacProj.cpp
+++ b/Source/MaestroMacProj.cpp
@@ -135,6 +135,15 @@ void Maestro::MacProj(Vector<std::array<MultiFab, AMREX_SPACEDIM> >& umac,
     // Set up implicit solve using MLABecLaplacian class
     //
     LPInfo info;
+    info.setMetricTerm(false);
+    
+    if (mg_bottom_solver == 4) {
+        info.setAgglomeration(true);
+        info.setConsolidation(true);
+    } else {
+        info.setAgglomeration(false);
+        info.setConsolidation(false);
+    }
 
     // Only pass up to defined level to prevent looping over undefined grids.
     MLABecLaplacian mlabec(Geom(0, finest_level), grids, dmap, info);

--- a/Source/MaestroMacProj.cpp
+++ b/Source/MaestroMacProj.cpp
@@ -136,7 +136,7 @@ void Maestro::MacProj(Vector<std::array<MultiFab, AMREX_SPACEDIM> >& umac,
     //
     LPInfo info;
     info.setMetricTerm(false);
-    
+
     if (mg_bottom_solver == 4) {
         info.setAgglomeration(true);
         info.setConsolidation(true);

--- a/Source/MaestroNodalProj.cpp
+++ b/Source/MaestroNodalProj.cpp
@@ -168,9 +168,15 @@ void Maestro::NodalProj(int proj_type, Vector<MultiFab>& rhcc,
     }
 
     LPInfo info;
-    info.setAgglomeration(true);
-    info.setConsolidation(true);
     info.setMetricTerm(false);
+    
+    if (hg_bottom_solver == 4) {
+        info.setAgglomeration(true);
+        info.setConsolidation(true);
+    } else {
+        info.setAgglomeration(false);
+        info.setConsolidation(false);
+    }
 
     // Only pass up to defined level to prevent looping over undefined grids.
     MLNodeLaplacian mlndlap(Geom(0, finest_level), grids, dmap, info);

--- a/Source/MaestroNodalProj.cpp
+++ b/Source/MaestroNodalProj.cpp
@@ -169,7 +169,7 @@ void Maestro::NodalProj(int proj_type, Vector<MultiFab>& rhcc,
 
     LPInfo info;
     info.setMetricTerm(false);
-    
+
     if (hg_bottom_solver == 4) {
         info.setAgglomeration(true);
         info.setConsolidation(true);

--- a/Source/param/_cpp_parameters
+++ b/Source/param/_cpp_parameters
@@ -248,11 +248,13 @@ mg_cycle_type                       int            3
 # Type of cycle used in the nodal multigrid -- 1 = F-cycle, 2 = W-cycle, 3 = V-cycle
 hg_cycle_type                       int            3
 
-# valid values are $\ge$ 0
-hg_bottom_solver                    int            -1
+# 4 is the fancy agglomerating bottom solver
+# otherwise it uses the default MLMG non-agglomerating
+hg_bottom_solver                    int            4
 
-# valid values are $\ge$ 0
-mg_bottom_solver                    int            -1
+# 4 is the fancy agglomerating bottom solver
+# otherwise it uses the default MLMG non-agglomerating
+mg_bottom_solver                    int            4
 
 # if mg\_bottom\_solver == 4, then how many mg levels can the bottom solver mgt object have
 max_mg_bottom_nlevels               int            1000


### PR DESCRIPTION
Enable control for toggling fancy bottom solver via maestro.mg_bottom_solver and maestro.hg_bottom_solver
Default is on (4) for both mg and hg.
Set it to any other value to use the default MLMG settings.