### PR TITLE
Fix average base state algorithm with split projection for spherical case

### DIFF
--- a/Exec/test_problems/imposed_external_heating/MaestroBaseState.cpp
+++ b/Exec/test_problems/imposed_external_heating/MaestroBaseState.cpp
@@ -3,11 +3,8 @@
 
 using namespace amrex;
 
-void
-Maestro::InitBaseState(BaseState<Real>& rho0_s, BaseState<Real>& rhoh0_s,
-                       BaseState<Real>& p0_s,
-                       const int lev)
-{
+void Maestro::InitBaseState(BaseState<Real>& rho0_s, BaseState<Real>& rhoh0_s,
+                            BaseState<Real>& p0_s, const int lev) {
     // timer for profiling
     BL_PROFILE_VAR("Maestro::InitBaseState()", InitBaseState);
 
@@ -36,53 +33,57 @@ Maestro::InitBaseState(BaseState<Real>& rho0_s, BaseState<Real>& rhoh0_s,
 
     // Set the state in the first cell in the vertical direction
     // ("the bottom")
-    const Real z0 = 0.5*base_geom.dr(n); // generic "z", actually 2d/3d agnostic
+    const Real z0 =
+        0.5 * base_geom.dr(n);  // generic "z", actually 2d/3d agnostic
 
-    const Real a  = 2.0;
-    const Real b  = 2.0;
+    const Real a = 2.0;
+    const Real b = 2.0;
     const Real Ts = 1.0;
     const Real pi = 3.14159265358979323844;
-    const Real c  = H/pi;
+    const Real c = H / pi;
 
     // set p0 and rho0 based on analytical value at the cc coord
-    p0_init_arr(n,0) = a + b*H; // 22
-    s0_init_arr(n,0,Rho) = b + 1.0;  // 3
+    p0_init_arr(n, 0) = a + b * H;     // 22
+    s0_init_arr(n, 0, Rho) = b + 1.0;  // 3
 
     eos_t eos_state;
 
     // use eos call to be consistent
-    eos_state.p = p0_init_arr(n,0);
-    eos_state.rho = s0_init_arr(n,0,Rho);
+    eos_state.p = p0_init_arr(n, 0);
+    eos_state.rho = s0_init_arr(n, 0, Rho);
     for (auto comp = 0; comp < NumSpec; ++comp) {
         eos_state.xn[comp] = xn_zone[comp];
     }
-    eos_state.T = 1000.0; // just a guess
-    eos(eos_input_rp, eos_state); // (rho, p) --> T, h
+    eos_state.T = 1000.0;          // just a guess
+    eos(eos_input_rp, eos_state);  // (rho, p) --> T, h
 
     // set other base vars
-    s0_init_arr(n,0,RhoH) = eos_state.h;
+    s0_init_arr(n, 0, RhoH) = eos_state.h;
     for (auto comp = 0; comp < NumSpec; ++comp) {
-        s0_init_arr(n,0,FirstSpec+comp) = xn_zone[comp];
+        s0_init_arr(n, 0, FirstSpec + comp) = xn_zone[comp];
     }
-    s0_init_arr(n,0,Temp) = eos_state.T;
+    s0_init_arr(n, 0, Temp) = eos_state.T;
 
     for (auto r = 1; r < base_geom.nr(n); ++r) {
-
         // height above the bottom of the domain
         Real z = (Real(r) + 0.5) * base_geom.dr(n);
 
         // set rho analytically
-        Real dens_zone = cos(z/c) + b;
+        Real dens_zone = cos(z / c) + b;
         // needs to be set before pressure
-        s0_init_arr(n,r,Rho) = dens_zone;
+        s0_init_arr(n, r, Rho) = dens_zone;
 
         // compute the pressure by discretizing HSE
-        p0_init_arr(n,r) = p0_init_arr(n,r-1) - base_geom.dr(n) * 0.5 * (s0_init_arr(n,r,Rho) + s0_init_arr(n,r-1,Rho)) * fabs(grav_const);
+        p0_init_arr(n, r) =
+            p0_init_arr(n, r - 1) -
+            base_geom.dr(n) * 0.5 *
+                (s0_init_arr(n, r, Rho) + s0_init_arr(n, r - 1, Rho)) *
+                fabs(grav_const);
 
         // use the EOS to make the state consistent
-        eos_state.rho   = dens_zone;
-        eos_state.p     = p0_init_arr(n,r);
-        eos_state.T     = 1000.0; // guess
+        eos_state.rho = dens_zone;
+        eos_state.p = p0_init_arr(n, r);
+        eos_state.T = 1000.0;  // guess
         for (auto comp = 0; comp < NumSpec; ++comp) {
             eos_state.xn[comp] = xn_zone[comp];
         }
@@ -90,21 +91,20 @@ Maestro::InitBaseState(BaseState<Real>& rho0_s, BaseState<Real>& rhoh0_s,
         // (rho,p) --> T, h
         eos(eos_input_rp, eos_state);
 
-        s0_init_arr(n,r,RhoH) = dens_zone * eos_state.h;
+        s0_init_arr(n, r, RhoH) = dens_zone * eos_state.h;
         for (auto comp = 0; comp < NumSpec; ++comp) {
-            s0_init_arr(n,r,FirstSpec+comp) =
-                dens_zone * xn_zone[comp];
+            s0_init_arr(n, r, FirstSpec + comp) = dens_zone * xn_zone[comp];
         }
-        s0_init_arr(n,r,Temp) = eos_state.T;
+        s0_init_arr(n, r, Temp) = eos_state.T;
     }
 
     // copy s0_init and p0_init into rho0, rhoh0, p0, and tempbar
     for (auto r = 0; r < base_geom.nr_fine; ++r) {
-        rho0(lev,r) = s0_init_arr(lev,r,Rho);
-        rhoh0(lev,r) = s0_init_arr(lev,r,RhoH);
-        tempbar_arr(lev,r) = s0_init_arr(lev,r,Temp);
-        tempbar_init_arr(lev,r) = s0_init_arr(lev,r,Temp);
-        p0(lev,r) = p0_init_arr(lev,r);
+        rho0(lev, r) = s0_init_arr(lev, r, Rho);
+        rhoh0(lev, r) = s0_init_arr(lev, r, RhoH);
+        tempbar_arr(lev, r) = s0_init_arr(lev, r, Temp);
+        tempbar_init_arr(lev, r) = s0_init_arr(lev, r, Temp);
+        p0(lev, r) = p0_init_arr(lev, r);
     }
 
     // initialize any inlet BC parameters

--- a/Exec/test_problems/imposed_external_heating/MaestroInitData.cpp
+++ b/Exec/test_problems/imposed_external_heating/MaestroInitData.cpp
@@ -3,10 +3,8 @@
 using namespace amrex;
 
 // initializes data on a specific level
-void
-Maestro::InitLevelData(const int lev, const Real time,
-                       const MFIter& mfi, const Array4<Real> scal, const Array4<Real> vel)
-{
+void Maestro::InitLevelData(const int lev, const Real time, const MFIter& mfi,
+                            const Array4<Real> scal, const Array4<Real> vel) {
     // timer for profiling
     BL_PROFILE_VAR("Maestro::InitLevelData()", InitLevelData);
 
@@ -17,20 +15,20 @@ Maestro::InitLevelData(const int lev, const Real time,
     }
 
     // set velocity the correct value c sin(y/c)/(cos(y/c)+b)
-    const Real H=10.0;
-    const Real pi_=3.141592653589793238462643383279;
-    const Real c=H/pi_;
-    const Real a=2;
-    const Real b=2;
+    const Real H = 10.0;
+    const Real pi_ = 3.141592653589793238462643383279;
+    const Real c = H / pi_;
+    const Real a = 2;
+    const Real b = 2;
     const auto prob_lo = geom[lev].ProbLoArray();
     const auto prob_hi = geom[lev].ProbHiArray();
     const auto dx = geom[lev].CellSizeArray();
 
     AMREX_PARALLEL_FOR_4D(tileBox, AMREX_SPACEDIM, i, j, k, n, {
         const Real y = prob_lo[1] + (Real(j) + 0.5) * dx[1];
-        vel(i,j,k,n) = 0.0;
+        vel(i, j, k, n) = 0.0;
         if (n == 2) {
-            vel(i,j,k,n) = c * sin(y/c)/(cos(y/c)+b);
+            vel(i, j, k, n) = c * sin(y / c) / (cos(y / c) + b);
         }
     });
 
@@ -41,14 +39,14 @@ Maestro::InitLevelData(const int lev, const Real time,
         int r = AMREX_SPACEDIM == 2 ? j : k;
 
         // set the scalars using s0
-        scal(i,j,k,Rho) = s0_arr(lev,r,Rho);
-        scal(i,j,k,RhoH) = s0_arr(lev,r,RhoH);
-        scal(i,j,k,Temp) = s0_arr(lev,r,Temp);
+        scal(i, j, k, Rho) = s0_arr(lev, r, Rho);
+        scal(i, j, k, RhoH) = s0_arr(lev, r, RhoH);
+        scal(i, j, k, Temp) = s0_arr(lev, r, Temp);
         for (auto comp = 0; comp < NumSpec; ++comp) {
-            scal(i,j,k,FirstSpec+comp) = s0_arr(lev,r,FirstSpec+comp);
+            scal(i, j, k, FirstSpec + comp) = s0_arr(lev, r, FirstSpec + comp);
         }
         // initialize pi to zero for now
-        scal(i,j,k,Pi) = 0.0;
+        scal(i, j, k, Pi) = 0.0;
     });
 
     AMREX_PARALLEL_FOR_3D(tileBox, i, j, k, {
@@ -56,7 +54,7 @@ Maestro::InitLevelData(const int lev, const Real time,
         const Real x = prob_lo[0] + (Real(i) + 0.5) * dx[0];
         const Real y = prob_lo[1] + (Real(j) + 0.5) * dx[1];
 
-        const Real rho0 = s0_arr(lev,r,Rho);
+        const Real rho0 = s0_arr(lev, r, Rho);
 
         Real rho_local = 0.0;
 
@@ -65,27 +63,26 @@ Maestro::InitLevelData(const int lev, const Real time,
         eos_t eos_state;
 
         eos_state.rho = rho_local;
-        eos_state.p = p0_arr(lev,r);
-        eos_state.T = s0_arr(lev,r,Temp);
+        eos_state.p = p0_arr(lev, r);
+        eos_state.T = s0_arr(lev, r, Temp);
         for (auto comp = 0; comp < NumSpec; ++comp) {
-            eos_state.xn[comp] = 1.0; // single fluid
+            eos_state.xn[comp] = 1.0;  // single fluid
         }
 
         // (rho,p) --> T, h
         eos(eos_input_rp, eos_state);
 
-        scal(i,j,k,Rho) = eos_state.rho;
-        scal(i,j,k,RhoH) = eos_state.rho * eos_state.h;
-        scal(i,j,k,Temp) = eos_state.T;
+        scal(i, j, k, Rho) = eos_state.rho;
+        scal(i, j, k, RhoH) = eos_state.rho * eos_state.h;
+        scal(i, j, k, Temp) = eos_state.T;
         for (auto comp = 0; comp < NumSpec; ++comp) {
-            scal(i,j,k,FirstSpec+comp) = eos_state.rho * eos_state.xn[comp];
+            scal(i, j, k, FirstSpec + comp) =
+                eos_state.rho * eos_state.xn[comp];
         }
     });
 }
 
-void
-Maestro::InitLevelDataSphr(const int lev, const Real time,
-			   MultiFab& scal, MultiFab& vel)
-{
+void Maestro::InitLevelDataSphr(const int lev, const Real time, MultiFab& scal,
+                                MultiFab& vel) {
     Abort("InitLevelDataSphr is not implemented.");
 }

--- a/Source/Maestro.H
+++ b/Source/Maestro.H
@@ -417,8 +417,9 @@ class Maestro : public amrex::AmrCore {
 
     /// Print out the contents of the base state
     void PrintBase(const RealVector& base, const bool is_cell_centered = true);
-    
-    void PrintBase(const BaseState<amrex::Real>& base, const bool is_cell_centered = true);
+
+    void PrintBase(const BaseState<amrex::Real>& base,
+                   const bool is_cell_centered = true);
 
     /// Print out the contents of a Vector of MultiFabs
     void PrintMF(const amrex::Vector<amrex::MultiFab>& MF);

--- a/Source/MaestroAdvanceAvg.cpp
+++ b/Source/MaestroAdvanceAvg.cpp
@@ -295,11 +295,11 @@ void Maestro::AdvanceTimeStepAverage(bool is_initIter) {
             // compute Sbar = average(S_cc_nph)
             Average(S_cc_nph, Sbar, 0);
 
-	    // save old-time value
+            // save old-time value
             w0_old.copy(w0);
 
-	    // reset w0
-	    w0.setVal(0.0);
+            // reset w0
+            w0.setVal(0.0);
         }
     }
 
@@ -324,10 +324,10 @@ void Maestro::AdvanceTimeStepAverage(bool is_initIter) {
     // compute w0 just before the projection
     if (evolve_base_state) {
         if (split_projection) {
-	    is_predictor = true;
-	    Makew0(w0_old, w0_force_dummy, Sbar, rho0_old, rho0_old, p0_old,
-		   p0_old, gamma1bar_old, gamma1bar_old, p0_minus_peosbar, dt,
-		   dtold, is_predictor);
+            is_predictor = true;
+            Makew0(w0_old, w0_force_dummy, Sbar, rho0_old, rho0_old, p0_old,
+                   p0_old, gamma1bar_old, gamma1bar_old, p0_minus_peosbar, dt,
+                   dtold, is_predictor);
             Put1dArrayOnCart(w0, w0_cart, true, true, bcs_u, 0, 1);
 
 #if (AMREX_SPACEDIM == 3)
@@ -338,9 +338,9 @@ void Maestro::AdvanceTimeStepAverage(bool is_initIter) {
 #endif
         } else {
             w0.setVal(0.0);
-	    for (int lev = 0; lev <= finest_level; ++lev) {
-		w0_cart[lev].setVal(0.);
-	    }
+            for (int lev = 0; lev <= finest_level; ++lev) {
+                w0_cart[lev].setVal(0.);
+            }
         }
     }
 
@@ -371,9 +371,9 @@ void Maestro::AdvanceTimeStepAverage(bool is_initIter) {
         Addw0(umac, w0mac, 1.);
         // reset w0
         w0.setVal(0.0);
-	for (int lev = 0; lev <= finest_level; ++lev) {
-	    w0_cart[lev].setVal(0.);
-	}
+        for (int lev = 0; lev <= finest_level; ++lev) {
+            w0_cart[lev].setVal(0.);
+        }
     }
 
     //////////////////////////////////////////////////////////////////////////////
@@ -472,7 +472,7 @@ void Maestro::AdvanceTimeStepAverage(bool is_initIter) {
         if (!spherical) {
             if (split_projection) {
                 MakeEtarhoPlanar(s1, s2, umac);
-            } 
+            }
         } else {
             MakeEtarhoSphr(s1, s2, umac, w0mac_dummy);
         }
@@ -636,9 +636,9 @@ void Maestro::AdvanceTimeStepAverage(bool is_initIter) {
     if (evolve_base_state) {
         if (split_projection) {
             is_predictor = false;
-	    Makew0(w0_old, w0_force_dummy, Sbar, rho0_old, rho0_old, p0_old,
-		   p0_old, gamma1bar_old, gamma1bar_old, p0_minus_peosbar, dt,
-		   dtold, is_predictor);
+            Makew0(w0_old, w0_force_dummy, Sbar, rho0_old, rho0_old, p0_old,
+                   p0_old, gamma1bar_old, gamma1bar_old, p0_minus_peosbar, dt,
+                   dtold, is_predictor);
             Put1dArrayOnCart(w0, w0_cart, true, true, bcs_u, 0, 1);
 
 #if (AMREX_SPACEDIM == 3)
@@ -649,10 +649,10 @@ void Maestro::AdvanceTimeStepAverage(bool is_initIter) {
 #endif
         } else {
             w0.setVal(0.0);
-	    for (int lev = 0; lev <= finest_level; ++lev) {
-		w0_cart[lev].setVal(0.);
-	    }
-	}
+            for (int lev = 0; lev <= finest_level; ++lev) {
+                w0_cart[lev].setVal(0.);
+            }
+        }
     }
 
     // compute RHS for MAC projection, beta0*(S_cc-Sbar) + beta0*delta_chi
@@ -682,9 +682,9 @@ void Maestro::AdvanceTimeStepAverage(bool is_initIter) {
         Addw0(umac, w0mac, 1.);
         // reset w0
         w0.setVal(0.0);
-	for (int lev = 0; lev <= finest_level; ++lev) {
-	    w0_cart[lev].setVal(0.);
-	}
+        for (int lev = 0; lev <= finest_level; ++lev) {
+            w0_cart[lev].setVal(0.);
+        }
     }
 
     //////////////////////////////////////////////////////////////////////////////
@@ -884,15 +884,15 @@ void Maestro::AdvanceTimeStepAverage(bool is_initIter) {
     // compute w0 just before the projection
     if (evolve_base_state) {
         if (split_projection) {
-	    is_predictor = false;
-	    Makew0(w0_old, w0_force_dummy, Sbar, rho0_new, rho0_new, p0_new,
-		   p0_new, gamma1bar_new, gamma1bar_new, p0_minus_peosbar, dt,
-		   dtold, is_predictor);
+            is_predictor = false;
+            Makew0(w0_old, w0_force_dummy, Sbar, rho0_new, rho0_new, p0_new,
+                   p0_new, gamma1bar_new, gamma1bar_new, p0_minus_peosbar, dt,
+                   dtold, is_predictor);
         } else {
             w0.setVal(0.0);
         }
-	
-	Put1dArrayOnCart(w0, w0_cart, true, true, bcs_u, 0, 1);
+
+        Put1dArrayOnCart(w0, w0_cart, true, true, bcs_u, 0, 1);
     }
 
     if (evolve_base_state && split_projection) {
@@ -975,9 +975,9 @@ void Maestro::AdvanceTimeStepAverage(bool is_initIter) {
 
         // reset w0
         w0.setVal(0.0);
-	for (int lev = 0; lev <= finest_level; ++lev) {
-	    w0_cart[lev].setVal(0.);
-	}
+        for (int lev = 0; lev <= finest_level; ++lev) {
+            w0_cart[lev].setVal(0.);
+        }
     }
 
     beta0_nm1.copy(0.5 * (beta0_old + beta0_new));

--- a/Source/MaestroAdvanceAvg.cpp
+++ b/Source/MaestroAdvanceAvg.cpp
@@ -421,7 +421,7 @@ void Maestro::AdvanceTimeStepAverage(bool is_initIter) {
 
     // advect rhoX, rho, and tracers
     DensityAdvance(1, s1, s2, sedge, sflux, scal_force, etarhoflux_dummy, umac,
-                   w0mac, rho0_pred_edge_dummy);
+                   w0mac_dummy, rho0_pred_edge_dummy);
 
     // correct the base state density by "averaging"
     if (evolve_base_state) {
@@ -465,7 +465,7 @@ void Maestro::AdvanceTimeStepAverage(bool is_initIter) {
         Print() << "            : enthalpy_advance >>>" << std::endl;
     }
 
-    EnthalpyAdvance(1, s1, s2, sedge, sflux, scal_force, umac, w0mac, thermal1);
+    EnthalpyAdvance(1, s1, s2, sedge, sflux, scal_force, umac, w0mac_dummy, thermal1);
 
     if (evolve_base_state && use_etarho) {
         // compute the new etarho
@@ -711,7 +711,7 @@ void Maestro::AdvanceTimeStepAverage(bool is_initIter) {
 
     // advect rhoX, rho, and tracers
     DensityAdvance(2, s1, s2, sedge, sflux, scal_force, etarhoflux_dummy, umac,
-                   w0mac, rho0_pred_edge_dummy);
+                   w0mac_dummy, rho0_pred_edge_dummy);
 
     // correct the base state density by "averaging"
     if (evolve_base_state) {
@@ -754,7 +754,7 @@ void Maestro::AdvanceTimeStepAverage(bool is_initIter) {
         Print() << "            : enthalpy_advance >>>" << std::endl;
     }
 
-    EnthalpyAdvance(2, s1, s2, sedge, sflux, scal_force, umac, w0mac, thermal1);
+    EnthalpyAdvance(2, s1, s2, sedge, sflux, scal_force, umac, w0mac_dummy, thermal1);
 
     if (evolve_base_state && use_etarho) {
         // compute the new etarho

--- a/Source/MaestroAdvanceAvg.cpp
+++ b/Source/MaestroAdvanceAvg.cpp
@@ -465,7 +465,8 @@ void Maestro::AdvanceTimeStepAverage(bool is_initIter) {
         Print() << "            : enthalpy_advance >>>" << std::endl;
     }
 
-    EnthalpyAdvance(1, s1, s2, sedge, sflux, scal_force, umac, w0mac_dummy, thermal1);
+    EnthalpyAdvance(1, s1, s2, sedge, sflux, scal_force, umac, w0mac_dummy,
+                    thermal1);
 
     if (evolve_base_state && use_etarho) {
         // compute the new etarho
@@ -754,7 +755,8 @@ void Maestro::AdvanceTimeStepAverage(bool is_initIter) {
         Print() << "            : enthalpy_advance >>>" << std::endl;
     }
 
-    EnthalpyAdvance(2, s1, s2, sedge, sflux, scal_force, umac, w0mac_dummy, thermal1);
+    EnthalpyAdvance(2, s1, s2, sedge, sflux, scal_force, umac, w0mac_dummy,
+                    thermal1);
 
     if (evolve_base_state && use_etarho) {
         // compute the new etarho

--- a/Source/MaestroDebug.cpp
+++ b/Source/MaestroDebug.cpp
@@ -23,7 +23,8 @@ void Maestro::PrintBase(const RealVector& base, const bool is_cell_centered) {
     }
 }
 
-void Maestro::PrintBase(const BaseState<Real>& base_s, const bool is_cell_centered) {
+void Maestro::PrintBase(const BaseState<Real>& base_s,
+                        const bool is_cell_centered) {
     // timer for profiling
     BL_PROFILE_VAR("Maestro::PrintBase()", PrintBase);
 
@@ -35,8 +36,8 @@ void Maestro::PrintBase(const BaseState<Real>& base_s, const bool is_cell_center
             auto hi = is_cell_centered ? base_geom.r_end_coord(lev, i)
                                        : base_geom.r_end_coord(lev, i) + 1;
             for (auto r = lo; r <= hi; ++r) {
-		std::cout << std::setprecision(16) << "base lev, r " << lev << ", " << r << ", "
-                        << base(lev, r) << std::endl;
+                std::cout << std::setprecision(16) << "base lev, r " << lev
+                          << ", " << r << ", " << base(lev, r) << std::endl;
             }
         }
     }

--- a/Source/MaestroForce.cpp
+++ b/Source/MaestroForce.cpp
@@ -156,12 +156,12 @@ void Maestro::MakeVelForce(
                 const Array4<const Real> w0macx_arr = w0mac[lev][0].array(mfi);
                 const Array4<const Real> w0macy_arr = w0mac[lev][1].array(mfi);
                 const Array4<const Real> uold_arr = uold[lev].array(mfi);
-		const auto omega_loc = omega;
+                const auto omega_loc = omega;
 #endif
 
                 // AMREX_PARALLEL_FOR_3D(tileBox, i, j, k, {
-	        amrex::ParallelFor(
-                tileBox, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                amrex::ParallelFor(tileBox, [=] AMREX_GPU_DEVICE(
+                                                int i, int j, int k) noexcept {
 #ifdef ROTATION
                     const Real x = prob_lo[0] + (Real(i) + 0.5) * dx[0];
                     const Real y = prob_lo[1] + (Real(j) + 0.5) * dx[1];

--- a/Source/MaestroMakeEta.cpp
+++ b/Source/MaestroMakeEta.cpp
@@ -327,13 +327,15 @@ void Maestro::MakeEtarhoPlanar(
             AMREX_PARALLEL_FOR_3D(tilebox, i, j, k, {
 
 #if (AMREX_SPACEDIM == 2)
-                Real U_dot_er = 0.5 *(vmac(i, j, k) + vmac(i, j + 1, k));
+                Real U_dot_er = 0.5 * (vmac(i, j, k) + vmac(i, j + 1, k));
 #else
                 Real U_dot_er = 0.5 *(vmac(i, j, k) + vmac(i, j, k + 1));
 #endif
                 // construct time-centered [ rho' (U dot e_r) ]
                 eta_cart_arr(i, j, k) =
-                    (0.5 * (rho_old(i, j, k) + rho_new(i, j, k))- rho0_nph_cart_arr(i,j,k) ) * U_dot_er;
+                    (0.5 * (rho_old(i, j, k) + rho_new(i, j, k)) -
+                     rho0_nph_cart_arr(i, j, k)) *
+                    U_dot_er;
             });
         }  // end MFIter loop
     }      // end loop over levels


### PR DESCRIPTION
This PR fixes the average base state algorithm for spherical problems by moving the computation of `w0` to just before the MAC and nodal projection steps as is currently done with planar problems. Preliminary testing of wdconvect shows that this fix (average base) gives similar solution trends as the original algorithm (advect base). 

![wdconvect](https://user-images.githubusercontent.com/35239173/99303161-4efbbb80-2805-11eb-90fa-56b003c4d145.png)

This fix should not affect the planar case.

Note that `split_projection = true` is now the default setting when using the average base state algorithm.