### PR TITLE
Update to C++17 as minimum standard

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 21.01
+
+  * C++17 is now the minimum supported C++ standard.
+
 # 20.12
 
   * Set default in SDC algorithm to use split projection for both planar and spherical problems 

--- a/Exec/Make.Maestro
+++ b/Exec/Make.Maestro
@@ -18,6 +18,9 @@ MICROPHYSICS_HOME ?= $(TOP)/external/Microphysics
 
 AMREX_HOME ?= $(TOP)/external/amrex
 
+# Require C++17
+CXXSTD := c++17
+
 # Check to make sure that Microphysics actually exists,
 # using an arbitrary file that must exist to check.
 # Throw an error if we don't have Microphysics.

--- a/sphinx_docs/source/getting_started.rst
+++ b/sphinx_docs/source/getting_started.rst
@@ -9,7 +9,7 @@ and how to look at the output.
 Requirements
 ============
 
-MAESTROeX requires a C++ compiler that supports the C++11 standard, a 
+MAESTROeX requires a C++ compiler that supports the C++17 standard, a
 Fortran compiler that supports the Fortran 2003 standard, and a C compiler 
 that supports the C99 standard. Several compiler suites are supported, 
 including GNU, Intel, PGI and Cray. GNU Make (>= 3.82) is also required, 
@@ -17,7 +17,7 @@ as is Python (>= 3.6) and standard tools available in any Unix-like
 environments (e.g., Perl and ``sed``). 
 
 For running in parallel, an MPI library and/or OpenMP is required. 
-For running on GPUs, CUDA 10 or later is required (see :ref:`sec:gpu` for 
+For running on GPUs, CUDA 11 or later is required (see :ref:`sec:gpu` for
 more information).
 
 Quick Start


### PR DESCRIPTION
C++17 is now the minimum supported standard for MAESTROeX. This means that gcc >= 7 and nvcc >= 11 are now required.

Among other C++17 features we want to use inline variables (starkiller-astro/Microphysics#482) and if constexpr (starkiller-astro/Microphysics#470).