### PR TITLE
correct (swap) labels for tfromp and tfromh in the output

### DIFF
--- a/Source/MaestroPlot.cpp
+++ b/Source/MaestroPlot.cpp
@@ -893,8 +893,8 @@ Vector<std::string> Maestro::PlotFileVarNames(int* nPlot) const {
     if (plot_Hnuc) {
         names[cnt++] = "Hnuc";
     }
-    names[cnt++] = "tfromh";
     names[cnt++] = "tfromp";
+    names[cnt++] = "tfromh";
     names[cnt++] = "deltap";
     names[cnt++] = "deltaT";
     names[cnt++] = "Pi";


### PR DESCRIPTION
The labels were switched around -- I suspect that was unintentional.