### PR TITLE
Update getting_started.rst

### DIFF
--- a/sphinx_docs/source/getting_started.rst
+++ b/sphinx_docs/source/getting_started.rst
@@ -58,7 +58,7 @@ paper 3.
    If you choose to use the submodule, enter the ``MAESTROeX/``
    directory and type::
 
-      git submodule --init
+      git submodule init
 
    Note that in the future when you pull MAESTROeX, to make sure the
    Microphysics submodule is also updated you must instead use::


### PR DESCRIPTION
Fixed usage of "git submodule"
"git submodule --init" is invalid since no command is specified