### PR TITLE
fix sphinx4 latex macro rendering

### DIFF
--- a/sphinx_docs/source/conf.py
+++ b/sphinx_docs/source/conf.py
@@ -115,17 +115,17 @@ todo_include_todos = False
 
 
 # -- Options for MathJax
-mathjax_config = {'TeX': {'Macros': {}}}
+mathjax3_config = {'tex': {'macros': {}}}
 
 with open('mathsymbols.tex', 'r') as f:
     for line in f:
         macros = re.findall(r'\\newcommand{\\(.*?)}(\[(\d)\])?{(.+)}', line)
         for macro in macros:
             if len(macro[1]) == 0:
-                mathjax_config['TeX']['Macros'][macro[0]
+                mathjax3_config['tex']['macros'][macro[0]
                                                 ] = "{" + macro[3] + "}"
             else:
-                mathjax_config['TeX']['Macros'][macro[0]] = [
+                mathjax3_config['tex']['macros'][macro[0]] = [
                     "{" + macro[3] + "}", int(macro[2])]
 
 


### PR DESCRIPTION
sphinx 4 defaults to mathjax 3 which needs different syntax for the latex macros used in the docs.