### PR TITLE
add problem namespace to the problem runtime parameters

### DIFF
--- a/Exec/science/code_comp/_parameters
+++ b/Exec/science/code_comp/_parameters
@@ -1,3 +1,5 @@
+@namespace: problem
+
   heating_factor      real 9.020952262e19
   g0                  real -9.021899571e8
   rho_0                real 1.82094e6

--- a/Exec/science/ecsn/_parameters
+++ b/Exec/science/ecsn/_parameters
@@ -1,3 +1,5 @@
+@namespace: problem
+
 velpert_amplitude         real 1.e5
 velpert_amplitude         real 1.e6
 velpert_radius            real 2.e7

--- a/Exec/science/flame/_parameters
+++ b/Exec/science/flame/_parameters
@@ -1,3 +1,5 @@
+@namespace: problem
+
 # For a simple laminar flame setup we define the fuel and ash state.  The
 # fuel parameters will be used to define the inflow boundary condition.
 # the fuel and ash will be in pressure equilibrium, so the ash density

--- a/Exec/science/fully_convective_star/_parameters
+++ b/Exec/science/fully_convective_star/_parameters
@@ -1,3 +1,5 @@
+@namespace: problem
+
 velpert_amplitude         real 1.e5
 velpert_radius            real 2.e7
 velpert_scale             real 1.e7

--- a/Exec/science/plane_parallel_star/_parameters
+++ b/Exec/science/plane_parallel_star/_parameters
@@ -1,3 +1,5 @@
+@namespace: problem
+
 velpert_amplitude         real 1.e5
 velpert_amplitude         real 1.e6
 velpert_radius            real 2.e7

--- a/Exec/science/rotating_star/_parameters
+++ b/Exec/science/rotating_star/_parameters
@@ -1,3 +1,5 @@
+@namespace: problem
+
 velpert_amplitude         real 1.e5
 velpert_radius            real 2.e7
 velpert_scale             real 1.e7

--- a/Exec/science/sub_chandra/_parameters
+++ b/Exec/science/sub_chandra/_parameters
@@ -1,3 +1,5 @@
+@namespace: problem
+
 # Set velocity perturbations to help seed convection
 velpert_amplitude                   real               0.d0                
 velpert_scale                       real               0.8d8               

--- a/Exec/science/toy_convect/_parameters
+++ b/Exec/science/toy_convect/_parameters
@@ -1,3 +1,5 @@
+@namespace: problem
+
 # Velocity field initialization
 apply_vel_field                     logical            .false.
 

--- a/Exec/science/urca/_parameters
+++ b/Exec/science/urca/_parameters
@@ -1,3 +1,5 @@
+@namespace: problem
+
 velpert_amplitude         real 1.e5
 velpert_radius            real 2.e7
 velpert_scale             real 1.e7

--- a/Exec/science/urca/analysis/_parameters
+++ b/Exec/science/urca/analysis/_parameters
@@ -1,2 +1,4 @@
+@namespace: problem
+
 small_temp    real        1.e4
 small_dens    real        1.e-4

--- a/Exec/science/wdconvect/_parameters
+++ b/Exec/science/wdconvect/_parameters
@@ -1,3 +1,5 @@
+@namespace: problem
+
 velpert_amplitude         real 1.e5
 velpert_amplitude         real 1.e6
 velpert_radius            real 2.e7

--- a/Exec/science/xrb_mixed/_parameters
+++ b/Exec/science/xrb_mixed/_parameters
@@ -1,3 +1,4 @@
+@namespace: problem
 
 # Magnitude of the perturbation.
 xrb_pert_factor                     real               1.d-2               

--- a/Exec/test_problems/double_bubble/_parameters
+++ b/Exec/test_problems/double_bubble/_parameters
@@ -1,3 +1,5 @@
+@namespace: problem
+
 pert_factor     real      8.1d-3
 pres_base       real      1.65d6
 dens_base       real      1.65d-3

--- a/Exec/test_problems/incomp_shear_jet/_parameters
+++ b/Exec/test_problems/incomp_shear_jet/_parameters
@@ -1,3 +1,5 @@
+@namespace: problem
+
 yt        real  0.0333333333333d0
 delx      real  0.05d0
 rho_base  real  1.0d0

--- a/Exec/test_problems/mach_jet/_parameters
+++ b/Exec/test_problems/mach_jet/_parameters
@@ -1,3 +1,5 @@
+@namespace: problem
+
 # max mach number at inflow
 inlet_mach       real    1.d-1
 do_stratified    logical .false.

--- a/Exec/test_problems/reacting_bubble/_parameters
+++ b/Exec/test_problems/reacting_bubble/_parameters
@@ -1,3 +1,5 @@
+@namespace: problem
+
 pert_temp_factor  real      1.d0
 pert_rad_factor   real      1.d0
 do_small_domain   logical   .false.

--- a/Exec/test_problems/rt/_parameters
+++ b/Exec/test_problems/rt/_parameters
@@ -1,3 +1,5 @@
+@namespace: problem
+
 rho_1           real      1.d0
 rho_2           real      2.d0
 vel_amplitude   real      0.25d0

--- a/Exec/test_problems/test_convect/_parameters
+++ b/Exec/test_problems/test_convect/_parameters
@@ -1,3 +1,5 @@
+@namespace: problem
+
 apply_vel_field     logical   .true.
 velpert_scale       real      5.d6
 velpert_amplitude   real      1.d5

--- a/Exec/test_problems/test_planar_diag/_parameters
+++ b/Exec/test_problems/test_planar_diag/_parameters
@@ -1,3 +1,5 @@
+@namespace: problem
+
 pres_base       real      1d13
 dens_base       real      1d0
 scale_height    real      1d9

--- a/Exec/test_problems/test_stability/_parameters
+++ b/Exec/test_problems/test_stability/_parameters
@@ -1,3 +1,5 @@
+@namespace: problem
+
 velpert_amplitude                   real               0.d0                
 velpert_radius                      real               0.75d8              
 velpert_scale                       real               0.8d8               

--- a/Exec/unit_tests/test_advect/_parameters
+++ b/Exec/unit_tests/test_advect/_parameters
@@ -1,3 +1,5 @@
+@namespace: problem
+
 advect_test_tol             real              1.d-14
 do_bds                      logical           .false.
 dir                         integer           1

--- a/Exec/unit_tests/test_basestate/_parameters
+++ b/Exec/unit_tests/test_basestate/_parameters
@@ -1,3 +1,5 @@
+@namespace: problem
+
 heating_time          real           0.5d0
 heating_rad           real           0.d0
 heating_peak          real           1.d16

--- a/Exec/unit_tests/test_diffusion/_parameters
+++ b/Exec/unit_tests/test_diffusion/_parameters
@@ -1,3 +1,5 @@
+@namespace: problem
+
 # t0 used in the initialization of Gaussian pulse (c.f. Swesty \& Myra, ApJSS 181, 1-52 (2009))
 t0                                  real               1.d-9
 

--- a/Exec/unit_tests/test_eos/_parameters
+++ b/Exec/unit_tests/test_eos/_parameters
@@ -1,3 +1,5 @@
+@namespace: problem
+
 dens_min         real     1.d6
 dens_max         real     1.d9
 

--- a/Exec/unit_tests/test_projection/_parameters
+++ b/Exec/unit_tests/test_projection/_parameters
@@ -1,3 +1,5 @@
+@namespace: problem
+
 run_prefix   character   ""
 
 # project_type == 1 is hgproject, project_type == 2 is macproject

--- a/Exec/unit_tests/test_react/_parameters
+++ b/Exec/unit_tests/test_react/_parameters
@@ -1,3 +1,5 @@
+@namespace: problem
+
 dens_min      real       1.d6
 dens_max      real       1.d9
 temp_min      real       1.d6


### PR DESCRIPTION
they were defaulting to `None` which meant they couldn't be set in inputs