### PR TITLE
fix velocity perturbation for urca and wdconvect

### DIFF
--- a/Exec/science/urca/MaestroInitData.cpp
+++ b/Exec/science/urca/MaestroInitData.cpp
@@ -73,6 +73,59 @@ void Maestro::InitLevelDataSphr(const int lev, const Real time, MultiFab& scal,
         MultiFab::Copy(scal, temp_mf, 0, FirstSpec + comp, 1, 0);
     }
 
+    // random numbers between -1 and 1
+    GpuArray<Real, 27> alpha;
+    GpuArray<Real, 27> beta;
+    GpuArray<Real, 27> gamma;
+
+    // random numbers between 0 and 2*pi
+    GpuArray<Real, 27> phix;
+    GpuArray<Real, 27> phiy;
+    GpuArray<Real, 27> phiz;
+
+    // compute the norm of k
+    GpuArray<Real, 27> normk;
+
+    if (ParallelDescriptor::IOProcessor()) {
+        // Only the I/O process executes this
+        for (auto k = 1; k <= 3; ++k) {
+            for (auto j = 1; j <= 3; ++j) {
+                for (auto i = 1; i <= 3; ++i) {
+                    const int n = i - 1 + 3 * (j - 1 + 3 * (k - 1));
+
+                    normk[n] =
+                        std::sqrt(Real(i * i) + Real(j * j) + Real(k * k));
+
+                    alpha[n] = 2.0 * amrex::Random() - 1.0;
+                    beta[n] = 2.0 * amrex::Random() - 1.0;
+                    gamma[n] = 2.0 * amrex::Random() - 1.0;
+
+                    phix[n] = 2.0 * M_PI * amrex::Random();
+                    phiy[n] = 2.0 * M_PI * amrex::Random();
+                    phiz[n] = 2.0 * M_PI * amrex::Random();
+                }
+            }
+        }
+    }
+
+    ParallelDescriptor::Barrier();
+
+    // Broadcast perturbation from the I/O Processor
+    ParallelDescriptor::Bcast(normk.data(), normk.size(),
+                        ParallelDescriptor::IOProcessorNumber());
+    ParallelDescriptor::Bcast(alpha.data(), alpha.size(),
+                        ParallelDescriptor::IOProcessorNumber());
+    ParallelDescriptor::Bcast(beta.data(), beta.size(),
+                        ParallelDescriptor::IOProcessorNumber());
+    ParallelDescriptor::Bcast(gamma.data(), gamma.size(),
+                        ParallelDescriptor::IOProcessorNumber());
+    ParallelDescriptor::Bcast(phix.data(), phix.size(),
+                        ParallelDescriptor::IOProcessorNumber());
+    ParallelDescriptor::Bcast(phiy.data(), phiy.size(),
+                        ParallelDescriptor::IOProcessorNumber());
+    ParallelDescriptor::Bcast(phiz.data(), phiz.size(),
+                        ParallelDescriptor::IOProcessorNumber());
+
 #ifdef _OPENMP
 #pragma omp parallel
 #endif
@@ -106,49 +159,7 @@ void Maestro::InitLevelDataSphr(const int lev, const Real time, MultiFab& scal,
             scal_arr(i, j, k, Temp) = eos_state.T;
         });
 
-        // random numbers between -1 and 1
-        GpuArray<Real, 27> alpha;
-        GpuArray<Real, 27> beta;
-        GpuArray<Real, 27> gamma;
-
-        // random numbers between 0 and 2*pi
-        GpuArray<Real, 27> phix;
-        GpuArray<Real, 27> phiy;
-        GpuArray<Real, 27> phiz;
-
-        // compute the norm of k
-        GpuArray<Real, 27> normk;
-
-        for (auto k = 1; k <= 3; ++k) {
-            for (auto j = 1; j <= 3; ++j) {
-                for (auto i = 1; i <= 3; ++i) {
-                    const int n = i - 1 + 3 * (j - 1 + 3 * (k - 1));
-
-                    // alpha[n] = std::pow(0.5, i) * std::pow(0.7, j) * std::pow(0.3, k) * std::pow(-1.0, i);
-                    // beta[n] = std::pow(0.5, i) * std::pow(0.3, j) * std::pow(0.7, k) * std::pow(-1.0, j);
-                    // gamma[n] = std::pow(0.3, i) * std::pow(0.5, j) * std::pow(0.7, k) * std::pow(-1.0, k);
-
-                    // phix[n] = std::pow(0.3, i) * std::pow(0.7, j) * std::pow(0.5, k);
-                    // phix[n] *= 2.0 * M_PI;
-                    // phiy[n] = std::pow(0.7, i) * std::pow(0.3, j) * std::pow(0.5, k);
-                    // phiy[n] *= 2.0 * M_PI;
-                    // phiz[n] = std::pow(0.7, i) * std::pow(0.5, j) * std::pow(0.3, k);
-                    // phiz[n] *= 2.0 * M_PI;
-
-                    normk[n] =
-                        std::sqrt(Real(i * i) + Real(j * j) + Real(k * k));
-
-                    alpha[n] = 2.0 * amrex::Random() - 1.0;
-                    beta[n] = 2.0 * amrex::Random() - 1.0;
-                    gamma[n] = 2.0 * amrex::Random() - 1.0;
-
-                    phix[n] = 2.0 * M_PI * amrex::Random();
-                    phiy[n] = 2.0 * M_PI * amrex::Random();
-                    phiz[n] = 2.0 * M_PI * amrex::Random();
-                }
-            }
-        }
-
+        
         const auto prob_lo = geom[lev].ProbLoArray();
         const auto prob_hi = geom[lev].ProbHiArray();
         const auto dx = geom[lev].CellSizeArray();

--- a/Exec/science/wdconvect/MaestroInitData.cpp
+++ b/Exec/science/wdconvect/MaestroInitData.cpp
@@ -73,6 +73,59 @@ void Maestro::InitLevelDataSphr(const int lev, const Real time, MultiFab& scal,
         MultiFab::Copy(scal, temp_mf, 0, FirstSpec + comp, 1, 0);
     }
 
+    // random numbers between -1 and 1
+    GpuArray<Real, 27> alpha;
+    GpuArray<Real, 27> beta;
+    GpuArray<Real, 27> gamma;
+
+    // random numbers between 0 and 2*pi
+    GpuArray<Real, 27> phix;
+    GpuArray<Real, 27> phiy;
+    GpuArray<Real, 27> phiz;
+
+    // compute the norm of k
+    GpuArray<Real, 27> normk;
+
+    if (ParallelDescriptor::IOProcessor()) {
+        // Only the I/O process executes this
+        for (auto k = 1; k <= 3; ++k) {
+            for (auto j = 1; j <= 3; ++j) {
+                for (auto i = 1; i <= 3; ++i) {
+                    const int n = i - 1 + 3 * (j - 1 + 3 * (k - 1));
+
+                    normk[n] =
+                        std::sqrt(Real(i * i) + Real(j * j) + Real(k * k));
+
+                    alpha[n] = 2.0 * amrex::Random() - 1.0;
+                    beta[n] = 2.0 * amrex::Random() - 1.0;
+                    gamma[n] = 2.0 * amrex::Random() - 1.0;
+
+                    phix[n] = 2.0 * M_PI * amrex::Random();
+                    phiy[n] = 2.0 * M_PI * amrex::Random();
+                    phiz[n] = 2.0 * M_PI * amrex::Random();
+                }
+            }
+        }
+    }
+
+    ParallelDescriptor::Barrier();
+
+    // Broadcast perturbation from the I/O Processor
+    ParallelDescriptor::Bcast(normk.data(), normk.size(),
+                        ParallelDescriptor::IOProcessorNumber());
+    ParallelDescriptor::Bcast(alpha.data(), alpha.size(),
+                        ParallelDescriptor::IOProcessorNumber());
+    ParallelDescriptor::Bcast(beta.data(), beta.size(),
+                        ParallelDescriptor::IOProcessorNumber());
+    ParallelDescriptor::Bcast(gamma.data(), gamma.size(),
+                        ParallelDescriptor::IOProcessorNumber());
+    ParallelDescriptor::Bcast(phix.data(), phix.size(),
+                        ParallelDescriptor::IOProcessorNumber());
+    ParallelDescriptor::Bcast(phiy.data(), phiy.size(),
+                        ParallelDescriptor::IOProcessorNumber());
+    ParallelDescriptor::Bcast(phiz.data(), phiz.size(),
+                        ParallelDescriptor::IOProcessorNumber());
+
 #ifdef _OPENMP
 #pragma omp parallel
 #endif
@@ -106,49 +159,7 @@ void Maestro::InitLevelDataSphr(const int lev, const Real time, MultiFab& scal,
             scal_arr(i, j, k, Temp) = eos_state.T;
         });
 
-        // random numbers between -1 and 1
-        GpuArray<Real, 27> alpha;
-        GpuArray<Real, 27> beta;
-        GpuArray<Real, 27> gamma;
-
-        // random numbers between 0 and 2*pi
-        GpuArray<Real, 27> phix;
-        GpuArray<Real, 27> phiy;
-        GpuArray<Real, 27> phiz;
-
-        // compute the norm of k
-        GpuArray<Real, 27> normk;
-
-        for (auto k = 1; k <= 3; ++k) {
-            for (auto j = 1; j <= 3; ++j) {
-                for (auto i = 1; i <= 3; ++i) {
-                    const int n = i - 1 + 3 * (j - 1 + 3 * (k - 1));
-
-                    // alpha[n] = std::pow(0.5, i) * std::pow(0.7, j) * std::pow(0.3, k) * std::pow(-1.0, i);
-                    // beta[n] = std::pow(0.5, i) * std::pow(0.3, j) * std::pow(0.7, k) * std::pow(-1.0, j);
-                    // gamma[n] = std::pow(0.3, i) * std::pow(0.5, j) * std::pow(0.7, k) * std::pow(-1.0, k);
-
-                    // phix[n] = std::pow(0.3, i) * std::pow(0.7, j) * std::pow(0.5, k);
-                    // phix[n] *= 2.0 * M_PI;
-                    // phiy[n] = std::pow(0.7, i) * std::pow(0.3, j) * std::pow(0.5, k);
-                    // phiy[n] *= 2.0 * M_PI;
-                    // phiz[n] = std::pow(0.7, i) * std::pow(0.5, j) * std::pow(0.3, k);
-                    // phiz[n] *= 2.0 * M_PI;
-
-                    normk[n] =
-                        std::sqrt(Real(i * i) + Real(j * j) + Real(k * k));
-
-                    alpha[n] = 2.0 * amrex::Random() - 1.0;
-                    beta[n] = 2.0 * amrex::Random() - 1.0;
-                    gamma[n] = 2.0 * amrex::Random() - 1.0;
-
-                    phix[n] = 2.0 * M_PI * amrex::Random();
-                    phiy[n] = 2.0 * M_PI * amrex::Random();
-                    phiz[n] = 2.0 * M_PI * amrex::Random();
-                }
-            }
-        }
-
+        
         const auto prob_lo = geom[lev].ProbLoArray();
         const auto prob_hi = geom[lev].ProbHiArray();
         const auto dx = geom[lev].CellSizeArray();


### PR DESCRIPTION
The current implementation results in mpi processes and threads using different random parameters for the velocity perturbation. 

By calculating the parameters before the final loop and broadcasting, we ensure each process is using same velocity perturbation and so we get a smooth velocity field.