### PR TITLE
Initialize density from base state for Urca

### DIFF
--- a/Exec/science/urca/MaestroInitData.cpp
+++ b/Exec/science/urca/MaestroInitData.cpp
@@ -147,7 +147,6 @@ void Maestro::InitLevelDataSphr(const int lev, const Real time, MultiFab& scal,
 
         const Array4<const Real> p0_arr = p0_cart.array(mfi);
 
-        // initialize rho as sum of partial densities rho*X_i
         ParallelFor(tileBox, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
 
             // initialize (rho h) and T using the EOS

--- a/Exec/science/urca/MaestroInitData.cpp
+++ b/Exec/science/urca/MaestroInitData.cpp
@@ -58,6 +58,16 @@ void Maestro::InitLevelDataSphr(const int lev, const Real time, MultiFab& scal,
 
     Put1dArrayOnCart(lev, temp_vec, temp_mf, 0, 0, bcs_f, 0);
     MultiFab::Copy(scal, temp_mf, 0, Temp, 1, 0);
+    
+    // initialize demsity
+    for (auto l = 0; l <= base_geom.max_radial_level; ++l) {
+        for (auto r = 0; r < base_geom.nr(l); ++r) {
+            temp_arr(l, r) = s0_init_arr(l, r, Rho);
+        }
+    }
+
+    Put1dArrayOnCart(lev, temp_vec, temp_mf, 0, 0, bcs_f, 0);
+    MultiFab::Copy(scal, temp_mf, 0, Rho, 1, 0);
 
     // initialize p0_cart
     Put1dArrayOnCart(lev, p0_init, p0_cart, 0, 0);
@@ -139,9 +149,9 @@ void Maestro::InitLevelDataSphr(const int lev, const Real time, MultiFab& scal,
 
         // initialize rho as sum of partial densities rho*X_i
         ParallelFor(tileBox, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
-            for (auto comp = 0; comp < NumSpec; ++comp) {
-                scal_arr(i, j, k, Rho) += scal_arr(i, j, k, FirstSpec + comp);
-            }
+            //for (auto comp = 0; comp < NumSpec; ++comp) {
+            //    scal_arr(i, j, k, Rho) += scal_arr(i, j, k, FirstSpec + comp);
+            //}
 
             // initialize (rho h) and T using the EOS
             eos_t eos_state;

--- a/Exec/science/urca/MaestroInitData.cpp
+++ b/Exec/science/urca/MaestroInitData.cpp
@@ -149,9 +149,6 @@ void Maestro::InitLevelDataSphr(const int lev, const Real time, MultiFab& scal,
 
         // initialize rho as sum of partial densities rho*X_i
         ParallelFor(tileBox, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
-            //for (auto comp = 0; comp < NumSpec; ++comp) {
-            //    scal_arr(i, j, k, Rho) += scal_arr(i, j, k, FirstSpec + comp);
-            //}
 
             // initialize (rho h) and T using the EOS
             eos_t eos_state;

--- a/Exec/science/urca/MaestroInitData.cpp
+++ b/Exec/science/urca/MaestroInitData.cpp
@@ -59,7 +59,7 @@ void Maestro::InitLevelDataSphr(const int lev, const Real time, MultiFab& scal,
     Put1dArrayOnCart(lev, temp_vec, temp_mf, 0, 0, bcs_f, 0);
     MultiFab::Copy(scal, temp_mf, 0, Temp, 1, 0);
     
-    // initialize demsity
+    // initialize density
     for (auto l = 0; l <= base_geom.max_radial_level; ++l) {
         for (auto r = 0; r < base_geom.nr(l); ++r) {
             temp_arr(l, r) = s0_init_arr(l, r, Rho);


### PR DESCRIPTION
The current method initializes the density by summing the partial densities (rho X) from the composition.

The Urca initial models have steep compositional changes which lead to minor interpolation errors because of limiting. These are negligible as far as the reactions go, but because density is derived from this composition the simulation begins with some small density perturbations. These go on to grow larger and disrupt the simulation fairly quickly. see #321 

Instead by initializing the density directly from the base state, we ensure a smooth density profile.