### PR TITLE
disable a few C++ lint checks

### DIFF
--- a/.github/workflows/c-linter.yml
+++ b/.github/workflows/c-linter.yml
@@ -30,7 +30,7 @@ jobs:
           make_options: '-j 2 USE_OMP=FALSE USE_MPI=FALSE USE_CUDA=FALSE DIM=3 DEBUG=TRUE'
           ignore_files: 'amrex|Microphysics'
           header_filter: 'MAESTROeX'
-          checks: 'bugprone-*,performance-*,portability-*,modernize-*,clang-analyzer-*,cppcoreguidelines-*,readability-*,-cppcoreguidelines-pro-bounds-pointer-arithmetic,-cppcoreguidelines-pro-bounds-constant-array-index,-clang-diagnostic-unknown-warning-option,-clang-diagnostic-unknown-pragmas,-readability-avoid-const-params-in-decls,-cppcoreguidelines-owning-memory'
+          checks: 'bugprone-*,performance-*,portability-*,modernize-*,clang-analyzer-*,cppcoreguidelines-*,readability-*,-cppcoreguidelines-pro-bounds-pointer-arithmetic,-cppcoreguidelines-pro-bounds-constant-array-index,-clang-diagnostic-unknown-warning-option,-clang-diagnostic-unknown-pragmas,-readability-avoid-const-params-in-decls,-cppcoreguidelines-owning-memory,-cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers,-cppcoreguidelines-avoid-non-const-global-variables'
 
       - name: Archive clang tidy report
         uses: actions/upload-artifact@v1


### PR DESCRIPTION
this was flagging "0.5" in expressions as a magic number this also was flagging our global runtime parameters as non-const