### PR TITLE
check the burner status and abort if we fail

### DIFF
--- a/Source/MaestroBurner.cpp
+++ b/Source/MaestroBurner.cpp
@@ -39,6 +39,10 @@ void Maestro::Burner(const Vector<MultiFab>& s_in, Vector<MultiFab>& s_out,
         const BoxArray& fba = s_in[finelev].boxArray();
         const iMultiFab& mask = makeFineMask(s_in[lev], fba, IntVect(2));
 
+        ReduceOps<ReduceOpSum> reduce_op;
+        ReduceData<Real> reduce_data(reduce_op);
+        using ReduceTuple = typename decltype(reduce_data)::Type;
+
         // loop over boxes (make sure mfi takes a cell-centered multifab as an argument)
 #ifdef _OPENMP
 #pragma omp parallel
@@ -62,9 +66,12 @@ void Maestro::Burner(const Vector<MultiFab>& s_in, Vector<MultiFab>& s_out,
                           : rho_Hext[lev].array(mfi);
             const Array4<const int> mask_arr = mask.array(mfi);
 
-            ParallelFor(tileBox, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+
+            reduce_op.eval(tileBox, reduce_data,
+            [=] AMREX_GPU_HOST_DEVICE(int i, int j, int k) -> ReduceTuple
+            {
                 if (use_mask && mask_arr(i, j, k) == 1) {
-                    return;  // cell is covered by finer cells
+                    return {0.0};  // cell is covered by finer cells
                 }
                 auto rho = s_in_arr(i, j, k, Rho);
                 Real x_in[NumSpec];
@@ -96,6 +103,7 @@ void Maestro::Burner(const Vector<MultiFab>& s_in, Vector<MultiFab>& s_out,
                 burn_t state_in;
                 burn_t state_out;
 
+
                 Real x_out[NumSpec];
 #if NAUX_NET > 0
                 Real aux_out[NumAux];
@@ -103,14 +111,16 @@ void Maestro::Burner(const Vector<MultiFab>& s_in, Vector<MultiFab>& s_out,
                 Real rhowdot[NumSpec];
                 Real rhoH = 0.0;
 
+                Real burn_failed = 0.0_rt;
+
                 // if the threshold species is not in the network, then we burn
                 // normally.  if it is in the network, make sure the mass
                 // fraction is above the cutoff.
                 if ((rho > burning_cutoff_density_lo &&
                      rho < burning_cutoff_density_hi) &&
                     (ispec_threshold < 0 ||
-                     (ispec_threshold > 0 &&
-                      x_test > burner_threshold_cutoff))) {
+                     (ispec_threshold > 0 && x_test > burner_threshold_cutoff))) {
+
                     // Initialize burn state_in and state_out
                     state_in.e = 0.0;
                     state_in.rho = rho;
@@ -125,6 +135,8 @@ void Maestro::Burner(const Vector<MultiFab>& s_in, Vector<MultiFab>& s_out,
 #endif
 
                     // initialize state_out the same as state_in
+                    state_out.success = true;
+
                     state_out.e = 0.0;
                     state_out.rho = rho;
                     state_out.T = T_in;
@@ -142,6 +154,11 @@ void Maestro::Burner(const Vector<MultiFab>& s_in, Vector<MultiFab>& s_out,
                     state_out.k = k;
 
                     burner(state_out, dt_in);
+
+                    // if we were unsuccessful, update the failure count
+                    if (!state_out.success) {
+                        burn_failed = 1.0;
+                    }
 
                     for (int n = 0; n < NumSpec; ++n) {
                         x_out[n] = state_out.xn[n];
@@ -174,11 +191,9 @@ void Maestro::Burner(const Vector<MultiFab>& s_in, Vector<MultiFab>& s_out,
 
                 if (fabs(sumX - 1.0) > reaction_sum_tol) {
 #ifndef AMREX_USE_GPU
-                    Abort("ERROR: abundances do not sum to 1");
+                    amrex::Print() << "ERROR: abundances do not sum to 1";
 #endif
-                    for (int n = 0; n < NumSpec; ++n) {
-                        state_out.xn[n] /= sumX;
-                    }
+                    burn_failed = 1.0_rt;
                 }
 
                 // pass the density and pi through
@@ -207,7 +222,16 @@ void Maestro::Burner(const Vector<MultiFab>& s_in, Vector<MultiFab>& s_out,
                 s_out_arr(i, j, k, RhoH) = s_in_arr(i, j, k, RhoH) +
                                            dt_in * rho_Hnuc_arr(i, j, k) +
                                            dt_in * rho_Hext_arr(i, j, k);
+
+                return {burn_failed};
             });
+        }
+
+        ReduceTuple hv = reduce_data.value();
+        Real burn_failed = amrex::get<0>(hv);
+
+        if (burn_failed != 0.0) {
+            amrex::Abort("burning failed");
         }
     }
 }


### PR DESCRIPTION
this shifts the responsibility for aborting from Microphysics to MAESTROeX. Previously we would not abort on GPUs.  Now we do, since we do a reduce_op and handle the abort outside of the lambda kernel.