### PR TITLE
Fix test_diffusion

### DIFF
--- a/Exec/unit_tests/test_diffusion/MaestroEvolve.cpp
+++ b/Exec/unit_tests/test_diffusion/MaestroEvolve.cpp
@@ -102,16 +102,16 @@ void Maestro::Evolve() {
 
         // AdvanceTimeStep
         {
-            // thermal is the forcing for rhoh or temperature
-            MakeThermalCoeffs(sold, Tcoeff1, hcoeff1, Xkcoeff1, pcoeff1);
 
             // on the first step, just copy coeffs for the time centering
-            if (istep == 1) {
+            if (istep == start_step) {
+
+	        // compute diffusion coefficients and hold constant over simulation
+	        MakeThermalCoeffs(sold, Tcoeff1, hcoeff1, Xkcoeff1, pcoeff1);
                 for (int lev = 0; lev <= finest_level; ++lev) {
                     MultiFab::Copy(Tcoeff2[lev], Tcoeff1[lev], 0, 0, 1, 1);
                     MultiFab::Copy(hcoeff2[lev], hcoeff1[lev], 0, 0, 1, 1);
-                    MultiFab::Copy(Xkcoeff2[lev], Xkcoeff1[lev], 0, 0, NumSpec,
-                                   1);
+                    MultiFab::Copy(Xkcoeff2[lev], Xkcoeff1[lev], 0, 0, NumSpec, 1);
                     MultiFab::Copy(pcoeff2[lev], pcoeff1[lev], 0, 0, 1, 1);
                 }
             }
@@ -194,11 +194,7 @@ void Maestro::Evolve() {
 
         // fill the mfs for the next timestep by switching pointers
         for (int lev = 0; lev <= finest_level; ++lev) {
-            std::swap(sold[lev], snew[lev]);
-            std::swap(Tcoeff2[lev], Tcoeff1[lev]);
-            std::swap(hcoeff2[lev], hcoeff1[lev]);
-            std::swap(Xkcoeff2[lev], Xkcoeff1[lev]);
-            std::swap(pcoeff2[lev], pcoeff1[lev]);
+	     MultiFab::Copy(sold[lev], snew[lev], 0, 0, Nscal, ng_s);
         }
     }
 

--- a/Exec/unit_tests/test_diffusion/inputs_2d-256
+++ b/Exec/unit_tests/test_diffusion/inputs_2d-256
@@ -20,7 +20,7 @@ maestro.init_divu_iter        = 0
 maestro.init_iter             = 0
 
 # PLOTFILES
-maestro.plot_base_name  = diffuse_128_    # root name of plot file
+maestro.plot_base_name  = diffuse_256_    # root name of plot file
 maestro.plot_int   = -1   # number of timesteps between plot files
 maestro.plot_deltat = 0.02
 


### PR DESCRIPTION
Copy new state to old at end of each timestep rather than swap pointers
Fix a typo in the 256 inputs file

Results compared to exact now look good, clean 2nd order, by resolution (32-64-128-256):

L1norm = 0.001263424149, L2norm = 0.00254239622
L1norm = 0.0003189883239, L2norm = 0.0006351085439
L1norm = 8.09123031e-05, L2norm = 0.0001588140451
L1norm = 2.130357969e-05, L2norm = 3.995432598e-05
