### PR TITLE
add a new option: basestate_use_pres_model

### DIFF
--- a/Source/MaestroBaseState.cpp
+++ b/Source/MaestroBaseState.cpp
@@ -193,8 +193,13 @@ void Maestro::InitBaseState(BaseState<Real>& rho0, BaseState<Real>& rhoh0,
             }
 #endif
 
-            // (rho,T) --> p,h
-            eos(eos_input_rt, eos_state);
+            if (basestate_use_pres_model) {
+                // (rho,p) --> T,h
+                eos(eos_input_rp, eos_state);
+            } else {
+                // (rho,T) --> p,h
+                eos(eos_input_rt, eos_state);
+            }
 
             s0_init_arr(n, r, Rho) = d_ambient;
             s0_init_arr(n, r, RhoH) = d_ambient * eos_state.h;
@@ -209,7 +214,7 @@ void Maestro::InitBaseState(BaseState<Real>& rho0, BaseState<Real>& rhoh0,
             }
 #endif
             p0_init_arr(n, r) = eos_state.p;  // p_ambient !
-            s0_init_arr(n, r, Temp) = t_ambient;
+            s0_init_arr(n, r, Temp) = eos_state.T;
 
             // keep track of the height where we drop below the cutoff density
             if (s0_init_arr(n, r, Rho) <= base_cutoff_density &&

--- a/Source/param/_cpp_parameters
+++ b/Source/param/_cpp_parameters
@@ -43,6 +43,9 @@ perturb_model                       bool        false          y
 # print out HSE diagnostics as a function of r for the initial model
 print_init_hse_diag                 bool        false          y
 
+# do we use rho, T or rho, P from the initial model to establish thermodynamics
+basestate_use_pres_model            int         0              y
+
 #-----------------------------------------------------------------------------
 # category: timestepping
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
this allows us to use (rho, p) from the initial model instead of (rho, T) to establish the thermodynamics.