### PR TITLE
fix an issue with AMReX_BuildInfo.o

### DIFF
--- a/Exec/Make.Maestro
+++ b/Exec/Make.Maestro
@@ -259,6 +259,7 @@ ifdef BUILD_GIT_NAME
 endif
 
 $(objEXETempDir)/AMReX_buildInfo.o: .FORCE
+	@if [ ! -d $(objEXETempDir) ]; then mkdir -p $(objEXETempDir); fi
 	$(AMREX_HOME)/Tools/C_scripts/makebuildinfo_C.py \
           --amrex_home "$(AMREX_HOME)" \
           --COMP "$(COMP)" --COMP_VERSION "$(COMP_VERSION)" \


### PR DESCRIPTION
sometimes we haven't yet created the output directory at the point where this rule is executed