### PR TITLE
remove unused function

### DIFF
--- a/Source/BaseState.H
+++ b/Source/BaseState.H
@@ -238,10 +238,6 @@ class BaseState {
 
     T* dataPtr() noexcept { return base_data.dataPtr(); };
 
-    AMREX_GPU_HOST_DEVICE [[nodiscard]] AMREX_FORCE_INLINE T* dataPtr() const noexcept {
-        return this->dptr;
-    }
-
     /// scalar addition to the whole base state
     template <class U>
     friend BaseState<U> operator+(const U val, const BaseState<U>& p);


### PR DESCRIPTION
the basestate overload for dataptr was using this->dptr, but that does not seem to exist.  Not sure how this ever worked.